### PR TITLE
[WIP] Scala 2.13 port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/target
+.bloop
+/.bsp
+/.metals
+.DS_Store
+/project/project
+/project/target

--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,7 @@ lazy val commonSettings = Seq(
   name := "ostrich",
   organization := "uuverifiers",
   version := "1.0",
-  scalaVersion := "2.11.12",
-  crossScalaVersions := Seq("2.11.12", "2.12.10"),
+  scalaVersion := "2.13.5",
   publishTo := Some(Resolver.file("file",  new File( "/home/wv/public_html/maven/" )) ),
   scalacOptions ++= Seq(
     "-deprecation",
@@ -30,5 +29,3 @@ lazy val root = (project in file(".")).
     mainClass in Compile := Some("ostrich.OstrichMain"),
     unmanagedSourceDirectories in Test += baseDirectory.value / "replaceall-benchmarks" / "src" / "test" / "scala"
   )
-
-

--- a/build.sbt
+++ b/build.sbt
@@ -5,13 +5,23 @@ lazy val commonSettings = Seq(
   scalaVersion := "2.11.12",
   crossScalaVersions := Seq("2.11.12", "2.12.10"),
   publishTo := Some(Resolver.file("file",  new File( "/home/wv/public_html/maven/" )) ),
-  scalacOptions += "-deprecation",
+  scalacOptions ++= Seq(
+    "-deprecation",
+    //"-Xfatal-warnings",
+    "-unchecked",
+    "-Xlint",
+    "-Xelide-below", "FINE",
+    // "-feature",
+    // "-optimize",
+    "-Ywarn-dead-code",
+    "-Ywarn-unused"
+  ),
   resolvers += ("uuverifiers" at "http://logicrunch.research.it.uu.se/maven/").withAllowInsecureProtocol(true),
   libraryDependencies += "uuverifiers" %% "princess" % "nightly-SNAPSHOT",
   libraryDependencies += "uuverifiers" % "ecma2020-regex-parser" % "0.4-SNAPSHOT",
-  libraryDependencies += "org.sat4j" % "org.sat4j.core" % "2.3.1",
   libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.14.0" % "test",
-  libraryDependencies += "dk.brics.automaton" % "automaton" % "1.11-8"
+  libraryDependencies += "dk.brics.automaton" % "automaton" % "1.11-8",
+  libraryDependencies += "uuverifiers" %% "parikh-theory" % "0.1.0-SNAPSHOT"
 )
 
 lazy val root = (project in file(".")).

--- a/build.sbt
+++ b/build.sbt
@@ -19,8 +19,7 @@ lazy val commonSettings = Seq(
   libraryDependencies += "uuverifiers" %% "princess" % "nightly-SNAPSHOT",
   libraryDependencies += "uuverifiers" % "ecma2020-regex-parser" % "0.4-SNAPSHOT",
   libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.14.0" % "test",
-  libraryDependencies += "dk.brics.automaton" % "automaton" % "1.11-8",
-  libraryDependencies += "uuverifiers" %% "parikh-theory" % "0.1.0-SNAPSHOT"
+  libraryDependencies += "dk.brics.automaton" % "automaton" % "1.11-8"
 )
 
 lazy val root = (project in file(".")).

--- a/src/main/scala/ostrich/AutomataUtils.scala
+++ b/src/main/scala/ostrich/AutomataUtils.scala
@@ -128,11 +128,11 @@ object AutomataUtils {
     consideredAuts += newAut
 
     // add automata until we encounter a conflict
-    var cont = areConsistentAutomata(consideredAuts)
+    var cont = areConsistentAutomata(consideredAuts.toSeq)
     val oldAutsIt = oldAuts.iterator
     while (cont && oldAutsIt.hasNext) {
       consideredAuts += oldAutsIt.next
-      cont = areConsistentAutomata(consideredAuts)
+      cont = areConsistentAutomata(consideredAuts.toSeq)
     }
 
     if (cont)
@@ -141,11 +141,11 @@ object AutomataUtils {
     // remove automata to get a small core
     for (i <- (consideredAuts.size - 2) to 1 by -1) {
       val removedAut = consideredAuts remove i
-      if (areConsistentAutomata(consideredAuts))
+      if (areConsistentAutomata(consideredAuts.toSeq))
         consideredAuts.insert(i, removedAut)
     }
 
-    Some(consideredAuts)
+    Some(consideredAuts.toSeq)
   }
 
   /**
@@ -205,7 +205,7 @@ object AutomataUtils {
           if (isAccepting(reached) && wSize + 1 == len)
             return Some(newW.reverse)
           if (wSize + 1 < len)
-            todo push (reached, newW)
+            todo push ((reached, newW))
         }
     }
 
@@ -385,7 +385,7 @@ object AutomataUtils {
         states : Iterable[(A#State, A#State)]) : AtomicStateAutomaton = {
     val builder = aut.getBuilder
     val smap : Map[A#State, aut.State] =
-      aut.states.map(s => (s -> builder.getNewState))(collection.breakOut)
+      aut.states.iterator.map(s => (s -> builder.getNewState)).toMap
 
     for ((s1, lbl, s2) <- aut.transitions)
       for (newLbl <- aut.LabelOps.subtractLetter(a, lbl))
@@ -410,7 +410,7 @@ object AutomataUtils {
     val builder = aut.getBuilder
 
     val smap : Map[aut.State, aut.State] =
-      aut.states.map(s => (s -> builder.getNewState))(collection.breakOut)
+      aut.states.iterator.map(s => (s -> builder.getNewState)).toMap
 
     val initState = builder.initialState
     builder.setAccept(smap(aut.initialState), true)
@@ -434,9 +434,9 @@ object AutomataUtils {
     val builder = aut1.getBuilder
 
     val smap1 : Map[aut1.State, aut1.State] =
-      aut1.states.map(s => (s -> builder.getNewState))(collection.breakOut)
+      aut1.states.iterator.map(s => (s -> builder.getNewState)).toMap
     val smap2 : Map[aut2.State, aut1.State] =
-      aut2.states.map(s => (s -> builder.getNewState))(collection.breakOut)
+      aut2.states.iterator.map(s => (s -> builder.getNewState)).toMap
 
     builder.setInitialState(smap1(aut1.initialState))
     for (sf <- aut2.acceptingStates)
@@ -476,9 +476,9 @@ object AutomataUtils {
     val builder = autOuter.getBuilder
 
     val smapOuter : Map[autOuter.State, autOuter.State] =
-      autOuter.states.map(s => (s -> builder.getNewState))(collection.breakOut)
+      autOuter.states.iterator.map(s => (s -> builder.getNewState)).toMap
     val smapInner : Map[autInner.State, autOuter.State] =
-      autInner.states.map(s => (s -> builder.getNewState))(collection.breakOut)
+      autInner.states.iterator.map(s => (s -> builder.getNewState)).toMap
 
     val innerInit = smapInner(autInner.initialState)
     val innerFinal = autInner.acceptingStates.map(smapInner)

--- a/src/main/scala/ostrich/Automaton.scala
+++ b/src/main/scala/ostrich/Automaton.scala
@@ -40,12 +40,20 @@ import ap.terfor.conjunctions.{Conjunction, ReduceWithConjunction}
 
 import scala.collection.mutable.{BitSet => MBitSet,
                                  HashMap => MHashMap, HashSet => MHashSet,
-                                 ArrayStack}
+  ArrayStack}
+
+import ap.parser.{IExpression, IFormula}
+import uuverifiers.parikh_theory.{
+  Automaton => OtherAutomaton,
+  LengthCounting
+}
+
 
 /**
  * Interface for different implementations of finite-state automata.
  */
 trait Automaton {
+
   /**
    * Union
    */
@@ -190,7 +198,7 @@ trait TLabelEnumerator[TLabel] {
  * don't have any structure and are not composite, there is a unique
  * initial state, and a set of accepting states.
  */
-trait AtomicStateAutomaton extends Automaton {
+trait AtomicStateAutomaton extends Automaton with OtherAutomaton {
   /**
    * Type of states
    */
@@ -200,6 +208,8 @@ trait AtomicStateAutomaton extends Automaton {
    * Type of labels
    */
   type TLabel
+
+  type Label = TLabel
 
   /**
    * Operations on labels
@@ -257,9 +267,9 @@ trait AtomicStateAutomaton extends Automaton {
   /**
    * Iterate over all transitions
    */
-  def transitions : Iterator[(State, TLabel, State)] =
+  override def transitions : Iterator[(State, TLabel, State)] =
     for (s1 <- states.iterator; (s2, lbl) <- outgoingTransitions(s1))
-      yield (s1, lbl, s2)
+    yield (s1, lbl, s2)
 
   /**
    * Get image of a set of states under a given label
@@ -335,151 +345,14 @@ trait AtomicStateAutomaton extends Automaton {
   }
 
   /**
-   * Compute the length abstraction of this automaton. Special case of
-   * Parikh images, following the procedure in Verma et al, CADE 2005
-   */
-  lazy val getLengthAbstraction : Formula = /* Exploration.measure("length abstraction") */ {
+    * Compute the length abstraction of this automaton.
+    */
+  lazy val getLengthAbstraction: Formula = {
     import TerForConvenience._
     implicit val order = TermOrder.EMPTY
 
-    val stateSeq = states.toIndexedSeq
-    val state2Index = stateSeq.iterator.zipWithIndex.toMap
-
-    lazy val preStates = {
-      val preStates = Array.fill(stateSeq.size)(new MBitSet)
-
-      for ((from, _, to) <- transitions)
-        preStates(state2Index(to)) += state2Index(from)
-
-      preStates
-    }
-
-    lazy val transPreStates = {
-      val transPreStates = Array.fill(stateSeq.size)(new MBitSet)
-
-      for ((s1, s2) <- preStates.iterator zip transPreStates.iterator)
-        s2 ++= s1
-
-      for ((s, n) <- transPreStates.iterator.zipWithIndex)
-        s += n
-
-      // fixed-point iterator, to find transitively referenced states
-      var changed = true
-      while (changed) {
-        changed = false
-
-        for (i <- 0 until transPreStates.size) {
-          val set = transPreStates(i)
-
-          val oldSize = set.size
-          for (j <- 0 until transPreStates.size)
-            if (set contains j)
-              set |= transPreStates(j)
-
-          if (set.size > oldSize)
-            changed = true
-        }
-      }
-
-      transPreStates
-    }
-
-    val initialStateInd = state2Index(initialState)
-
-    ////////////////////////////////////////////////////////////////////////////
-
-    disjFor(for (finalState <- acceptingStates)
-            yield (uniqueLengthStates get finalState) match {
-
-    case Some(len) =>
-      v(0) === len
-
-    case None => {
-      val finalStateInd = state2Index(finalState)
-      val refStates = transPreStates(finalStateInd)
-
-      val productions : List[(Int, Option[Int])] =
-        (if (refStates contains initialStateInd)
-           List((initialStateInd, None))
-         else List()) :::
-        (for (state <- refStates.iterator;
-              preState <- preStates(state).iterator)
-         yield (state, Some(preState))).toList
-
-      val (prodVars, zVars, sizeVar) = {
-        val prodVars = for ((_, num) <- productions.zipWithIndex) yield v(num)
-        var nextVar = prodVars.size
-        val zVars = (for (state <- refStates.iterator) yield {
-          val ind = nextVar
-          nextVar = nextVar + 1
-          state -> v(ind)
-        }).toMap
-        (prodVars, zVars, v(nextVar))
-      }
-
-      // equations relating the production counters
-      val prodEqs =
-        (for (state <- refStates.iterator) yield {
-          LinearCombination(
-             (if (state == finalStateInd)
-                Iterator((IdealInt.ONE, OneTerm))
-              else
-                Iterator.empty) ++
-             (for (((source, targets), prodVar) <-
-                      productions.iterator zip prodVars.iterator;
-                    mult = (if (targets contains state) 1 else 0) -
-                           (if (source == state) 1 else 0))
-              yield (IdealInt(mult), prodVar)),
-             order)
-        }).toList
-
-      val sizeEq =
-        LinearCombination(
-          (for (((_, Some(_)), v) <- productions.iterator zip prodVars.iterator)
-           yield (IdealInt.ONE, v)) ++
-          Iterator((IdealInt.MINUS_ONE, sizeVar)),
-          order)
-
-      val entryZEq =
-        zVars(finalStateInd) - 1
-
-      val allEqs = eqZ(entryZEq :: sizeEq :: prodEqs)
-
-      val prodNonNeg =
-        prodVars >= 0
-
-      val prodImps =
-        (for (((source, _), prodVar) <-
-                productions.iterator zip prodVars.iterator;
-              if source != finalStateInd)
-         yield ((prodVar === 0) | (zVars(source) > 0))).toList
-
-      val zImps =
-        (for (state <- refStates.iterator; if state != finalStateInd) yield {
-           disjFor(Iterator(zVars(state) === 0) ++
-                   (for (((source, targets), prodVar) <-
-                           productions.iterator zip prodVars.iterator;
-                         if targets contains state)
-                    yield conj(zVars(state) === zVars(source) + 1,
-                               geqZ(List(prodVar - 1, zVars(source) - 1)))))
-         }).toList
-
-      val matrix =
-        conj(allEqs :: prodNonNeg :: prodImps ::: zImps)
-      val rawConstraint =
-        exists(prodVars.size + zVars.size, matrix)
-
-      val constraint =
-        ap.util.Timeout.withTimeoutMillis(1000) {
-          // best-effort attempt to get a quantifier-free version of the
-          // length abstraction
-          PresburgerTools.elimQuantifiersWithPreds(rawConstraint)
-        } {
-          ReduceWithConjunction(Conjunction.TRUE, order)(rawConstraint)
-        }
-
-      constraint
-    }})
+    val length = v(0)
+    (LengthCounting(IndexedSeq(this))) allowsMonoidValues Seq(length)
   }
 }
 

--- a/src/main/scala/ostrich/BricsAutomaton.scala
+++ b/src/main/scala/ostrich/BricsAutomaton.scala
@@ -35,8 +35,6 @@ package ostrich
 import dk.brics.automaton.{BasicAutomata, BasicOperations, RegExp, Transition,
                            Automaton => BAutomaton, State => BState}
 
-import scala.collection.JavaConversions.{asScalaIterator,
-                                         iterableAsScalaIterable}
 import scala.collection.mutable.{HashMap => MHashMap,
                                  HashSet => MHashSet,
                                  LinkedHashSet => MLinkedHashSet,
@@ -44,6 +42,7 @@ import scala.collection.mutable.{HashMap => MHashMap,
                                  TreeSet => MTreeSet,
                                  MultiMap => MMultiMap,
                                  Set => MSet}
+import scala.jdk.CollectionConverters._
 
 object BricsAutomaton {
   private def toBAutomaton(aut : Automaton) : BAutomaton = aut match {
@@ -230,8 +229,8 @@ class BricsTLabelEnumerator(labels: Iterator[(Char, Char)])
   def enumLabelOverlap(lbl : (Char, Char)) : Iterable[(Char, Char)] = {
     val (lMin, lMax) = lbl
     disjointLabels.
-      from((lMin, Char.MinValue)).
-      to((lMax, Char.MaxValue)).
+      rangeFrom((lMin, Char.MinValue)).
+      rangeTo((lMax, Char.MaxValue)).
       toIterable
   }
 
@@ -399,7 +398,7 @@ class BricsAutomaton(val underlying : BAutomaton) extends AtomicStateAutomaton {
   def outgoingTransitions(from : State) : Iterator[(State, TLabel)] = {
     val dests = new MHashMap[TLabel, MSet[State]] with MMultiMap[TLabel, State]
 
-    for (t <- from.getTransitions)
+    for (t <- from.getTransitions.asScala)
       dests.addBinding((t.getMin, t.getMax), t.getDest)
 
     val outgoing = new MLinkedHashSet[(State, TLabel)]
@@ -408,9 +407,9 @@ class BricsAutomaton(val underlying : BAutomaton) extends AtomicStateAutomaton {
 
       def sortingFn(s1 : State, s2 : State) : Boolean = {
         // sort by lowest outgoing transition
-        for ((t1, t2) <- s1.getSortedTransitions(false)
+        for ((t1, t2) <- s1.getSortedTransitions(false).asScala
                          zip
-                         s2.getSortedTransitions(false)) {
+                         s2.getSortedTransitions(false).asScala) {
           import scala.math.Ordering.Implicits._
           val lbl1 = (t1.getMin, t1.getMax)
           val lbl2 = (t2.getMin, t2.getMax)
@@ -514,7 +513,7 @@ class BricsAutomatonBuilder
 
   def outgoingTransitions(q : BricsAutomaton#State)
         : Iterator[(BricsAutomaton#State, BricsAutomaton#TLabel)] =
-    for (t <- q.getTransitions.iterator)
+    for (t <- q.getTransitions.asScala.iterator)
       yield (t.getDest, (t.getMin, t.getMax))
 
   def setAccept(q : BricsAutomaton#State, isAccepting : Boolean) : Unit =

--- a/src/main/scala/ostrich/BricsTransducer.scala
+++ b/src/main/scala/ostrich/BricsTransducer.scala
@@ -43,9 +43,9 @@ import dk.brics.automaton.{Automaton => BAutomaton,
                            State => BState,
                            Transition => BTransition}
 
-import scala.collection.JavaConversions.{iterableAsScalaIterable,asJavaCollection}
 
 import java.lang.StringBuilder
+import scala.collection.MapView
 
 object BricsTransducer {
   def apply() : BricsTransducer =
@@ -124,9 +124,9 @@ class TransducerState extends BState {
  * a character of output
  */
 class BricsTransducer(val initialState : BricsAutomaton#State,
-                      val lblTrans: Map[BricsAutomaton#State,
+                      val lblTrans: MapView[BricsAutomaton#State,
                                         Set[BricsTransducer#TTransition]],
-                      val eTrans: Map[BricsAutomaton#State,
+                      val eTrans: MapView[BricsAutomaton#State,
                                       Set[BricsTransducer#TETransition]],
                       val acceptingStates : Set[BricsAutomaton#State])
     extends Transducer {
@@ -728,11 +728,11 @@ class BricsTransducerBuilder
           worklist.push(snext)
     }
 
-    acceptingStates.retain(bwdReach.contains(_))
-    lblTrans.retain((k, v) => bwdReach.contains(k))
-    eTrans.retain((k, v) => bwdReach.contains(k))
-    lblTrans.foreach({ case (k, v) => v.retain(t => bwdReach.contains(dest(t))) })
-    eTrans.foreach({ case (k, v) => v.retain(t => bwdReach.contains(edest(t))) })
+    acceptingStates.filterInPlace(bwdReach.contains(_))
+    lblTrans.filterInPlace{case (k, v) => bwdReach.contains(k)}
+    eTrans.filterInPlace{case (k, v) => bwdReach.contains(k)}
+    lblTrans.foreach({ case (k, v) => v.filterInPlace(t => bwdReach.contains(dest(t))) })
+    eTrans.foreach({ case (k, v) => v.filterInPlace(t => bwdReach.contains(edest(t))) })
   }
 }
 

--- a/src/main/scala/ostrich/CaleyGraph.scala
+++ b/src/main/scala/ostrich/CaleyGraph.scala
@@ -35,8 +35,7 @@ package ostrich
 import java.util.Objects
 
 import scala.collection.mutable.{HashMap, HashSet, Set, Stack, MultiMap}
-import scala.collection.JavaConversions._
-import scala.collection.IterableView
+import scala.collection.MapView
 
 object Box {
   /**
@@ -171,10 +170,10 @@ object CaleyGraph {
   }
 
   private def getCharacterBoxes[A <: AtomicStateAutomaton](aut : A)
-      : Map[Box[A], Iterable[A#TLabel]] = {
+      : MapView[Box[A], Iterable[A#TLabel]] = {
     val ae = aut.labelEnumerator
     val boxes : Map[A#TLabel,Box[A]] =
-      ae.enumDisjointLabels.map(i => i -> new Box[A])(collection.breakOut)
+      ae.enumDisjointLabels.iterator.map(i => i -> new Box[A]).toMap
 
     for ((q1, i, q2) <- aut.transitions;
          i2 <- ae.enumLabelOverlap(i))

--- a/src/main/scala/ostrich/ConcatPreOp.scala
+++ b/src/main/scala/ostrich/ConcatPreOp.scala
@@ -34,9 +34,6 @@ package ostrich
 
 import ap.terfor.{Term, Formula, TermOrder, TerForConvenience}
 
-import scala.collection.JavaConversions.{asScalaIterator,
-                                         iterableAsScalaIterable}
-
 /**
  * Pre-image computation for the concatenation operator.
  */
@@ -113,7 +110,7 @@ object ConcatPreOp extends PreOp {
   override def lengthApproximation(arguments : Seq[Term], result : Term,
                                    order : TermOrder) : Formula = {
     import TerForConvenience._
-    implicit val _ = order
+    implicit val o = order
     result === arguments(0) + arguments(1)
   }
 

--- a/src/main/scala/ostrich/Exploration.scala
+++ b/src/main/scala/ostrich/Exploration.scala
@@ -749,24 +749,21 @@ class LazyExploration(_funApps : Seq[(PreOp, Seq[Term], Term)],
     private def intersection : Automaton = constraints reduceLeft (_ & _)
 
     def ensureCompleteLengthConstraints : Unit =
-      constraints match {
-        case Seq() | Seq(_) =>
-          // nothing, all length constraints already pushed
-        case auts =>
-          addLengthConstraint(TermConstraint(t, intersection),
-                              for (a <- constraints.toSeq)
-                              yield TermConstraint(t, a))
-      }
+      if (!constraints.isEmpty) {
+        addLengthConstraint(TermConstraint(t, intersection),
+                            for (a <- constraints.toSeq)
+                            yield TermConstraint(t, a))
+      } // nothing, all length constraints already pushed
 
     def getAcceptedWord : Seq[Int] =
       constraints match {
-        case Seq() => List()
+        case _ if constraints.isEmpty => List()
         case auts  => intersection.getAcceptedWord.get.toSeq
       }
 
     def getAcceptedWordLen(len : Int) : Seq[Int] =
       constraints match {
-        case Seq() => for (_ <- 0 until len) yield 0
+        case _ if constraints.isEmpty => for (_ <- 0 until len) yield 0
         case auts  => AutomataUtils.findAcceptedWord(auts.toSeq, len).get
       }
   }

--- a/src/main/scala/ostrich/OstrichSolver.scala
+++ b/src/main/scala/ostrich/OstrichSolver.scala
@@ -43,7 +43,6 @@ import ap.basetypes.IdealInt
 
 import dk.brics.automaton.{RegExp, Automaton => BAutomaton}
 
-import scala.collection.breakOut
 import scala.collection.mutable.{ArrayBuffer, HashMap => MHashMap}
 
 class OstrichSolver(theory : OstrichStringTheory,
@@ -248,10 +247,10 @@ class OstrichSolver(theory : OstrichStringTheory,
 
       val exploration =
         if (eagerMode)
-          Exploration.eagerExp(funApps, regexes, strDatabase,
+          Exploration.eagerExp(funApps.toSeq, regexes.toSeq, strDatabase,
                                lProver, lengthVars.toMap, useLength, flags)
         else
-          Exploration.lazyExp(funApps, regexes, strDatabase,
+          Exploration.lazyExp(funApps.toSeq, regexes.toSeq, strDatabase,
                               lProver, lengthVars.toMap, useLength, flags)
 
       exploration.findModel

--- a/src/main/scala/ostrich/OstrichStringTheoryBuilder.scala
+++ b/src/main/scala/ostrich/OstrichStringTheoryBuilder.scala
@@ -101,7 +101,7 @@ class OstrichStringTheoryBuilder extends StringTheoryBuilder {
         (name, aut)
       }
 
-    new OstrichStringTheory (symTransducers,
+    new OstrichStringTheory (symTransducers.toSeq,
                              OFlags(eagerAutomataOperations = eager,
                                     useLength = useLen,
                                     forwardApprox = forward))

--- a/src/main/scala/ostrich/ReplaceAllPreOp.scala
+++ b/src/main/scala/ostrich/ReplaceAllPreOp.scala
@@ -87,7 +87,7 @@ class ReplaceAllPreOpChar(a : Char) extends PreOp {
   override def lengthApproximation(arguments : Seq[Term], result : Term,
                                    order : TermOrder) : Formula = {
     import TerForConvenience._
-    implicit val _ = order
+    implicit val o = order
     (arguments(1) === 1 & result === arguments(0)) |
     (arguments(1) < 1 & result <= arguments(0)) |
     (arguments(1) > 1 & result >= arguments(0))

--- a/src/main/scala/ostrich/TransducerPreOp.scala
+++ b/src/main/scala/ostrich/TransducerPreOp.scala
@@ -32,7 +32,6 @@
 
 package ostrich
 
-import scala.collection.breakOut
 
 object TransducerPreOp {
   def apply(t : Transducer) = new TransducerPreOp(t)

--- a/src/test/scala/APITest.scala
+++ b/src/test/scala/APITest.scala
@@ -28,7 +28,7 @@ object APITest extends Properties("APITest") {
       import p._
 
       val x, y, z = createConstant(StringSort)
-      implicit val _ = decoderContext
+      implicit val context = decoderContext
 
       scope {
         !! (x === "abc")
@@ -62,7 +62,7 @@ object APITest extends Properties("APITest") {
       import p._
 
       val x, y, z = createConstant(StringSort)
-      implicit val _ = decoderContext
+      implicit val context = decoderContext
 
       scope {
         !! (x ++ y === y ++ x)

--- a/src/test/scala/SMTLIBTests.scala
+++ b/src/test/scala/SMTLIBTests.scala
@@ -3,7 +3,7 @@ package ostrich
 import ap.CmdlMain
 import ap.DialogUtil.asString
 
-import org.scalacheck.{Arbitrary, Gen, Properties}
+import org.scalacheck.Properties
 import org.scalacheck.Prop._
 
 object SMTLIBTests extends Properties("SMTLIBTests") {

--- a/src/test/scala/SMTLIBTests.scala
+++ b/src/test/scala/SMTLIBTests.scala
@@ -18,8 +18,13 @@ object SMTLIBTests extends Properties("SMTLIBTests") {
     expResult match {
       case "error" =>
         (result split "\n") exists { str => str contains "error" }
-      case res =>
-        (result split "\n") contains res
+      case res => {
+        // FIXME There is almost guaranteed to be a better way to debug this,
+        // but it beats me.
+        val doesMatch = (result split "\n") contains res
+        if(!doesMatch) println(result.strip())
+        doesMatch
+      }
     }
   }
 

--- a/src/test/scala/ostrich/CaleyGraphSpecification.scala
+++ b/src/test/scala/ostrich/CaleyGraphSpecification.scala
@@ -4,15 +4,18 @@ import org.scalacheck.{Arbitrary, Gen, Properties}
 import org.scalacheck.Prop._
 import dk.brics.automaton.{Automaton => BAutomaton, State, Transition}
 import scala.collection.mutable.Set
-import scala.collection.JavaConversions.iterableAsScalaIterable
+
+
+import scala.jdk.CollectionConverters._
 
 class PrintableState extends State {
   override def toString = "q" + hashCode
 }
 
 class IDState(val ident : Int) extends State {
+
   override def toString =
-    getTransitions.foldLeft("q" + ident + '\n') { (s, t) =>
+    getTransitions.asScala.foldLeft("q" + ident + '\n') { (s, t) =>
       val dest = t.getDest match {
         case d : IDState => "q" + d.ident
         case q => q.toString


### PR DESCRIPTION
This is a port to Scala 2.13. It's currently failing one test:
```
! APITest.len-no-regex: Exception raised on property evaluation.
[info] > Exception: ap.SimpleAPI$SimpleAPIForwardedException: Internal exception: java.lang.UnsupportedOperationException: empty.reduceLeft
```

Many of the API incompatibility fixes are also unbelievably dumb.

Should be merged to its own separate branch, or spliced out into a separate source tree.