### PR TITLE
add Javascript semantics of regex

### DIFF
--- a/src/main/scala/ostrich/OstrichSolver.scala
+++ b/src/main/scala/ostrich/OstrichSolver.scala
@@ -101,7 +101,7 @@ class OstrichSolver(theory : OstrichStringTheory,
 
     val wordExtractor = theory.WordExtractor(goal)
     val regexExtractor = theory.RegexExtractor(goal)
-    val cgTranslator = new Regex2PFA(theory)
+    val cgTranslator = new Regex2PFA(theory, new PythonPFABuilder)
 
 //    Console.err.println(atoms)
 

--- a/src/main/scala/ostrich/OstrichSolver.scala
+++ b/src/main/scala/ostrich/OstrichSolver.scala
@@ -101,7 +101,7 @@ class OstrichSolver(theory : OstrichStringTheory,
 
     val wordExtractor = theory.WordExtractor(goal)
     val regexExtractor = theory.RegexExtractor(goal)
-    val cgTranslator = new Regex2PFA(theory, new PythonPFABuilder)
+    val cgTranslator = new Regex2PFA(theory, new JavascriptPFABuilder)
 
 //    Console.err.println(atoms)
 

--- a/src/main/scala/ostrich/PFA.scala
+++ b/src/main/scala/ostrich/PFA.scala
@@ -559,17 +559,10 @@ class JavascriptPFABuilder extends PFABuilder {
   }
 
   def plus(aut : PFA) : PFA = {
-    Console.println("====debug of plus operator====")
-    Console.println("original:")
-    Console.println(aut.toDot)
     // aut will be modified during recursion
     // so we must make a copy here
     val autcopy = duplicate(aut)
-    Console.println("copy:")
-    Console.println(autcopy.toDot)
     val staraut = star(aut)
-    Console.println("star:")
-    Console.println(staraut.toDot)
     concat(autcopy, staraut)
   }
 
@@ -721,11 +714,8 @@ class Regex2PFA(theory : OstrichStringTheory, builder : PFABuilder) {
         }
         case IFunApp(`re_+`, Seq(a)) => {
           val (autA, capA) = buildPatternImpl(a)
-          val autplus = builder.plus(autA)
-          Console.println("the plus PFA:")
-          Console.println(autplus.toDot)
 
-          (autplus, capA)
+          (builder.plus(autA), capA)
         }
         case IFunApp(`re_+?`, Seq(a)) => {
           val (autA, capA) = buildPatternImpl(a)
@@ -822,8 +812,6 @@ class Regex2PFA(theory : OstrichStringTheory, builder : PFABuilder) {
 
     val cap2Init = (for ((cap, inits) <- Regex2PFA.capInit)
       yield (cap, inits.toSet)).toMap
-
-    Console.println(aut.toDot())
 
     (aut, numCapture, state2Capture, cap2Init)
   }

--- a/src/main/scala/ostrich/PFA.scala
+++ b/src/main/scala/ostrich/PFA.scala
@@ -51,12 +51,6 @@ import scala.collection.mutable.{HashMap => MHashMap,
 
 import java.lang.StringBuilder
 
-case class PFA(val sTran: MMap[PFA.State, Seq[PFA.SigmaTransition]],
-  val preTran: MMap[PFA.State, Seq[PFA.ETransition]],
-  val postTran: MMap[PFA.State, Seq[PFA.ETransition]],
-  val initial: PFA.State,
-  val accepting: PFA.State)
-
 object PFA {
 
   type State = BricsAutomaton#State
@@ -65,53 +59,82 @@ object PFA {
   type SigmaTransition = (TLabel, State)
   type ETransition = State
 
-  // the automaton,
-  // number of capture groups,
-  // number of stars,
-  // map from state to the capture groups it's in,
-  // map from state pair to stars which it resets
-  // map from star to the capture groups within
-  type completeInfo = (PFA, Int, Int, Map[State, Set[Int]], Map[(State, State), Set[Int]], Map[Int, Set[Int]])
-
-  private class GState extends BState {
-    override def toString = "qP" + hashCode
+  private class PFAState extends BState {
+    override def toString = "p" + hashCode
   }
 
-  private def getNewState : State = new GState
+  def getNewState : State = new PFAState
+}
 
-  def none() : PFA = {
-      val init = getNewState
-      val end = getNewState
-      val trans = new MHashMap[State, Seq[SigmaTransition]]
-      val pre = new MHashMap[State, Seq[ETransition]]
-      val post = new MHashMap[State, Seq[ETransition]]
-      PFA(trans, pre, post, init, end)
-  }
+// Prioritized Finite Automata
+// Contract :
+// 1. all transitions going out of `initial` are epsilon transition
+// 2. no input transition into `initial`
+// 3. no transition going out of any accepting state
+// The construction method is manifold, depending on the PFA builder chosen
+case class PFA(val sTran: MMap[PFA.State, Seq[PFA.SigmaTransition]],
+  val preTran: MMap[PFA.State, Seq[PFA.ETransition]],
+  val postTran: MMap[PFA.State, Seq[PFA.ETransition]],
+  val initial: PFA.State,
+  val accepting: (MSet[PFA.State], MSet[PFA.State]))
+{
+    def toDot() : String = {
+      val sb = new StringBuilder()
+      sb.append("digraph PFA {\n")
 
-  def epsilon() : PFA = {
-      val init = getNewState
-      val end = getNewState
-      val trans = new MHashMap[State, Seq[SigmaTransition]]
-      val pre = new MHashMap[State, Seq[ETransition]]
-      pre += ((init, Seq(end)))
-      val post = new MHashMap[State, Seq[ETransition]]
-      PFA(trans, pre, post, init, end)
-  }
+      sb.append(initial + "[shape=square];\n")
+      val (f1, f2) = accepting
+      for (s <- f1) {
+        sb.append(s + "[peripheries=2];\n")
+      }
+      for (s <- f2) {
+        sb.append(s + "[peripheries=2];\n")
+      }
 
-  def single(lbl : TLabel) : PFA = {
-    if (LabelOps isNonEmptyLabel lbl) {
-      val init = getNewState
-      val end = getNewState
-      val trans = new MHashMap[State, Seq[SigmaTransition]]
-      trans += ((init, Seq((lbl, end))))
-      val pre = new MHashMap[State, Seq[ETransition]]
-      val post = new MHashMap[State, Seq[ETransition]]
-      PFA(trans, pre, post, init, end)
-    } else {
-      none
+      var priority = Int.MaxValue
+      for (tran <- sTran) {
+        val (state, arrows) = tran
+        for (arrow <- arrows) {
+          val (lbl, dest) = arrow
+          sb.append(state + " -> " + dest);
+          sb.append("[label=\"" + lbl.toString + "/" + priority + "\"];\n")
+          priority -= 1
+        }
+      }
+
+      priority = Int.MaxValue
+      for ((s, arrow) <- preTran; dest <- arrow) {
+        sb.append(s + " -> " + dest);
+        sb.append("[label=\"preeps" + "/" + priority + "\"];\n")
+        priority -= 1
+      }
+
+      priority = Int.MaxValue
+      for ((s, arrow) <- postTran; dest <- arrow) {
+        sb.append(s + " -> " + dest);
+        sb.append("[label=\"posteps" + "/" + priority + "\"];\n")
+        priority -= 1
+      }
+
+      sb.append("}\n")
+
+      return sb.toString()
     }
   }
 
+// A PFA builder constructs PFA based on regular expression structure
+// following *certain* semantics of regex.
+abstract class PFABuilder {
+
+  type State = PFA.State
+  type TLabel = PFA.TLabel
+  val LabelOps : TLabelOps[TLabel] = PFA.LabelOps
+  type SigmaTransition = PFA.SigmaTransition
+  type ETransition = PFA.ETransition
+
+  def none() : PFA
+  def epsilon() : PFA
+  def single(lbl : TLabel) : PFA
   def constant(str: Seq[Int]) : PFA = {
     if (str.isEmpty) {
       epsilon
@@ -123,42 +146,106 @@ object PFA {
     }
   }
 
+  def alternate(aut1 : PFA, aut2 : PFA) : PFA
+  def concat(aut1 : PFA, aut2 : PFA) : PFA
+
+  def star(aut : PFA) : PFA
+  def lazystar(aut : PFA) : PFA
+  def plus(aut : PFA) : PFA
+  def lazyplus(aut : PFA) : PFA
+
+  def optional(aut : PFA) : PFA = {
+    alternate(aut, epsilon)
+  }
+}
+
+class PythonPFABuilder extends PFABuilder {
+  // In python mode, we don't use the second component
+  // of the accepted states because we don't differentiate these two types of acceptance condition
+  // thus, **all accepting states are in F1**
+  private val F2_dummy = new MHashSet[State]
+
+  import PFA.getNewState
+
+  def none() : PFA = {
+      val init = getNewState
+      val end = (new MHashSet[State], F2_dummy)
+      val trans = new MHashMap[State, Seq[SigmaTransition]]
+      val pre = new MHashMap[State, Seq[ETransition]]
+      val post = new MHashMap[State, Seq[ETransition]]
+      PFA(trans, pre, post, init, end)
+  }
+
+  def epsilon() : PFA = {
+      val init = getNewState
+      val F1 = new MHashSet[State]
+      val newaccepting = getNewState
+      F1 += newaccepting
+      val end = (F1, F2_dummy)
+      val trans = new MHashMap[State, Seq[SigmaTransition]]
+      val pre = new MHashMap[State, Seq[ETransition]]
+      pre += ((init, Seq(newaccepting)))
+      val post = new MHashMap[State, Seq[ETransition]]
+      PFA(trans, pre, post, init, end)
+  }
+
+  def single(lbl : TLabel) : PFA = {
+    if (LabelOps isNonEmptyLabel lbl) {
+      val init = getNewState
+      val intermediate = getNewState
+      val newaccepting = getNewState
+      val F1 = new MHashSet[State]
+      F1 += newaccepting
+      val end = (F1, F2_dummy)
+      val trans = new MHashMap[State, Seq[SigmaTransition]]
+      trans += ((intermediate, Seq((lbl, newaccepting))))
+      val pre = new MHashMap[State, Seq[ETransition]]
+      pre += ((init, Seq(intermediate)))
+      val post = new MHashMap[State, Seq[ETransition]]
+      PFA(trans, pre, post, init, end)
+    } else {
+      none
+    }
+  }
+
   def alternate(aut1 : PFA, aut2 : PFA) : PFA = {
     (aut1, aut2) match {
-      case (PFA(t1, pre1, post1, init1, end1), PFA(t2, pre2, post2, init2, end2)) => {
+      case (PFA(t1, pre1, post1, init1, (f1_1, _)), PFA(t2, pre2, post2, init2, (f1_2, _))) => {
         val init = getNewState
-        val end = getNewState
+        val f1 = f1_1 ++ f1_2
         val trans = t1 ++ t2
         val pre = pre1 ++ pre2
         pre += ((init, Seq(init1, init2)))
-        pre += ((end1, Seq(end)))
-        pre += ((end2, Seq(end)))
         val post = post1 ++ post2
 
-        PFA(trans, pre, post, init, end)
+        PFA(trans, pre, post, init, (f1, F2_dummy))
       }
     }
   }
 
   def concat(aut1 : PFA, aut2 : PFA) : PFA = {
     (aut1, aut2) match {
-      case (PFA(t1, pre1, post1, init1, end1), PFA(t2, pre2, post2, init2, end2)) => {
+      case (PFA(t1, pre1, post1, init1, (end1, _)), PFA(t2, pre2, post2, init2, (end2, _))) => {
         val trans = t1 ++ t2
         val pre = pre1 ++ pre2
-        pre += ((end1, Seq(init2)))
+        for (s <- end1) {
+          pre += ((s, Seq(init2)))
+        }
         val post = post1 ++ post2
 
-        PFA(trans, pre, post, init1, end2)
+        PFA(trans, pre, post, init1, (end2, F2_dummy))
       }
     }
   }
 
   def star(aut : PFA) : PFA = {
     aut match {
-      case PFA(t1, pre1, post1, init1, end1) => {
+      case PFA(t1, pre1, post1, init1, (end1, _)) => {
         val init = getNewState
         val end = getNewState
-        pre1 += ((end1, Seq(init1, end)))
+        for (s <- end1) {
+          pre1 += ((s, Seq(init1, end)))
+        }
         pre1 += ((init, Seq(init1, end)))
 
         //(post1 get init1) match {
@@ -169,18 +256,22 @@ object PFA {
             //post1(init1) = tgts :+ (end)
           //}
         //}
+        val f1 = new MHashSet[State]
+        f1 += end
 
-        PFA(t1, pre1, post1, init, end)
+        PFA(t1, pre1, post1, init, (f1, F2_dummy))
       }
     }
   }
 
   def lazystar(aut : PFA) : PFA = {
     aut match {
-      case PFA(t1, pre1, post1, init1, end1) => {
+      case PFA(t1, pre1, post1, init1, (end1, _)) => {
         val init = getNewState
         val end = getNewState
-        pre1 += ((end1, Seq(end, init1)))
+        for (s <- end1) {
+          pre1 += ((s, Seq(end, init1)))
+        }
         pre1 += ((init, Seq(end, init1)))
 
         //(pre1 get init1) match {
@@ -191,165 +282,168 @@ object PFA {
             //pre1(init1) = tgts.+:(end)
           //}
         //}
+        val f1 = new MHashSet[State]
+        f1 += end
 
-        PFA(t1, pre1, post1, init, end)
+        PFA(t1, pre1, post1, init, (f1, F2_dummy))
       }
     }
   }
 
   def plus(aut : PFA) : PFA = {
     aut match {
-      case PFA(t1, pre1, post1, init1, end1) => {
+      case PFA(t1, pre1, post1, init1, (end1, _)) => {
         val end = getNewState
-        pre1.+=((end1, Seq(init1, end)))
+        val init = getNewState
+        pre1 += ((init, Seq(init1)))
+        for (s <- end1) {
+          pre1 += ((s, Seq(init1, end)))
+        }
+        val f1 = new MHashSet[State]
+        f1 += end
 
-        PFA(t1, pre1, post1, init1, end)
+        PFA(t1, pre1, post1, init, (f1, F2_dummy))
       }
     }
   }
 
   def lazyplus(aut : PFA) : PFA = {
     aut match {
-      case PFA(t1, pre1, post1, init1, end1) => {
+      case PFA(t1, pre1, post1, init1, (end1, _)) => {
         val end = getNewState
-        pre1.+=((end1, Seq(end, init1)))
+        for (s <- end1) {
+          pre1.+=((s, Seq(end, init1)))
+        }
+        val f1 = new MHashSet[State]
+        f1 += end
 
-        PFA(t1, pre1, post1, init1, end)
+        PFA(t1, pre1, post1, init1, (f1, F2_dummy))
       }
     }
   }
 
-  def optional(aut : PFA) : PFA = {
-    alternate(aut, epsilon)
-  }
+}
 
-  def toDot(aut: PFA) : String = {
-    val sb = new StringBuilder()
-    sb.append("digraph PFA {\n")
+object Regex2PFA {
+  type State = PFA.State
+  type TLabel = PFA.TLabel
+  val LabelOps : TLabelOps[TLabel] = PFA.LabelOps
 
-    sb.append(aut.initial + "[shape=square];\n")
-    sb.append(aut.accepting + "[peripheries=2];\n")
-
-    var priority = Int.MaxValue
-    for (tran <- aut.sTran) {
-      val (state, arrows) = tran
-      for (arrow <- arrows) {
-        val (lbl, dest) = arrow
-        sb.append(state + " -> " + dest);
-        sb.append("[label=\"" + lbl.toString + "/" + priority + "\"];\n")
-        priority -= 1
-      }
-    }
-
-    priority = Int.MaxValue
-    for ((s, arrow) <- aut.preTran; dest <- arrow) {
-      sb.append(s + " -> " + dest);
-      sb.append("[label=\"preeps" + "/" + priority + "\"];\n")
-      priority -= 1
-    }
-
-    priority = Int.MaxValue
-    for ((s, arrow) <- aut.postTran; dest <- arrow) {
-      sb.append(s + " -> " + dest);
-      sb.append("[label=\"posteps" + "/" + priority + "\"];\n")
-      priority -= 1
-    }
-
-    sb.append("}\n")
-
-    return sb.toString()
-  }
+  // the automaton,
+  // number of capture groups,
+  // map from state to the capture groups it's in,
+  // map from capture group to initial states of its PFA counterpart
+  type completeInfo = (PFA, Int, Map[State, Set[Int]], Map[Int, Set[State]])
 
   def printInfo(info : completeInfo) = {
-    val (aut, numCap, numStar, state2Caps, states2Stars, star2Caps) = info
+    val (aut, numCap, state2Caps, cap2Init) = info
     Console.withOut(Console.err) {
-      println("   Generated  PNFA with " + numCap + " capture groups and " + numStar + " Klenne stars:")
-      println(PFA.toDot(aut))
+      println("   Generated PFA with " + numCap + " capture groups:")
+      println(aut.toDot)
       println("   State to Capture Groups:")
       for ((s, caps) <- state2Caps) {
         println(s + " -> { " + caps + " }")
       }
-      println("   States to Kleene Stars:")
-      for ((s, stars) <- states2Stars) {
-        println(s + " -> { " + stars + " }")
-      }
-      println("   Star to Capture Groups:")
-      for ((star, caps) <- star2Caps) {
-        println(star + " -> { " + caps + " }")
+      println("   Capture group to Initial States:")
+      for ((cap, inits) <- cap2Init) {
+        println(cap + " -> { " + inits + " }")
       }
     }
   }
+
+  // mutable maps collecting info during translation
+  val capState =
+    new MHashMap[Int, MSet[State]]
+    with MMultiMap[Int, State]
+  val stateCap =
+    new MHashMap[State, MSet[Int]]
+    with MMultiMap[State, Int]
+  val capInit =
+    new MHashMap[Int, MSet[State]]
+    with MMultiMap[Int, State]
 }
 
-class Regex2PFA(theory : OstrichStringTheory) {
+class Regex2PFA(theory : OstrichStringTheory, builder : PFABuilder) {
 
-  import PFA.completeInfo
-
-  type State = PFA.State
-  type TLabel = PFA.TLabel
-  val LabelOps : TLabelOps[TLabel] = AnchoredLabelOps
-
+  import Regex2PFA._
   import theory.{re_none, re_all, re_eps, re_allchar, re_charrange,
     re_++, re_union, re_inter, re_*, re_*?, re_+, re_+?, re_opt, re_comp,
     re_loop, str_to_re, re_from_str,
     re_begin_anchor, re_end_anchor,
     re_capture, re_reference, re_from_ecma2020}
 
-  val simplifier = new Regex2Aut.DiffEliminator(theory)
+  private val simplifier = new Regex2Aut.DiffEliminator(theory)
 
   // this is the map from literal numbering to internal numbering of
   // capture groups. It is for translating the replacement string.
   private val capNumTransform =
     new MHashMap[Int, Int]
 
+  def buildReplaceInfo(pat : ITerm, rep: ITerm) : (completeInfo, Seq[UpdateOp]) = {
+    reset
+
+    val info = buildPatternRegex(pat)
+    val ops = buildReplacementRegex(rep)
+
+    (info, ops)
+  }
+
+  def buildExtractInfo(index: Int, pat: ITerm) : (Int, completeInfo) = {
+    reset
+
+    val info = buildPatternRegex(pat)
+    val localindex =
+      (capNumTransform get index) match {
+        case None =>
+          throw new IllegalArgumentException("Undefined capture group referenced: " + index)
+        case Some(l) => l
+      }
+
+    (localindex, info)
+  }
+
+  def reset() = {
+    capNumTransform.clear
+    capState.clear
+    stateCap.clear
+    capInit.clear
+  }
+
   private def buildPatternRegex(pat : ITerm) : completeInfo = {
 
     var numCapture : Int = 0
-    var numStar : Int = 0
-
-    val capState =
-      new MHashMap[Int, MSet[State]]
-      with MMultiMap[Int, State]
-
-    // record the start and end state of subexpr, and capture groups within a star
-    val starInfo =
-      new MHashMap[Int, (State, State, Set[Int])]
 
     def buildPatternImpl(t : ITerm) : (PFA, Set[Int]) = { // returns PFA and capture groups within
       t match {
         case IFunApp(`re_none`, _) =>
-          (PFA.none, Set())
+          (builder.none, Set())
         case IFunApp(`re_eps`, _) =>
-          (PFA.epsilon, Set())
+          (builder.epsilon, Set())
         case IFunApp(`re_allchar`, _) =>
-          (PFA.single(LabelOps.sigmaLabel), Set())
+          (builder.single(LabelOps.sigmaLabel), Set())
         case IFunApp(`re_begin_anchor`, _) =>
-          (PFA.single(BeginAnchor), Set())
+          (builder.single(BeginAnchor), Set())
         case IFunApp(`re_end_anchor`, _) =>
-          (PFA.single(EndAnchor), Set())
+          (builder.single(EndAnchor), Set())
         case IFunApp(`re_all`, _) => {
-          val aut_allchar = PFA.single(LabelOps.sigmaLabel)
-          val aut_all = PFA.star(aut_allchar)
-          val localStarNum = numStar // considered as Kleene star Sigma*
-          numStar += 1
-
-          starInfo(localStarNum) = (aut_allchar.initial, aut_allchar.accepting, Set.empty[Int])
+          val aut_allchar = builder.single(LabelOps.sigmaLabel)
+          val aut_all = builder.star(aut_allchar)
           (aut_all, Set())
         }
         case IFunApp(`re_charrange`,
           Seq(IIntLit(IdealInt(a)), IIntLit(IdealInt(b)))) => {
             val lbl = LabelOps.interval(a.toChar, b.toChar) // XXX:Int to Char?
-            (PFA.single(lbl), Set())
+            (builder.single(lbl), Set())
         }
         case IFunApp(`re_++`, Seq(a, b)) => {
           val (autA, capA) = buildPatternImpl(a)
           val (autB, capB) = buildPatternImpl(b)
-          (PFA.concat(autA, autB), capA ++ capB)
+          (builder.concat(autA, autB), capA ++ capB)
         }
         case IFunApp(`re_union`, Seq(a, b)) => {
           val (autA, capA) = buildPatternImpl(a)
           val (autB, capB) = buildPatternImpl(b)
-          (PFA.alternate(autA, autB), capA ++ capB)
+          (builder.alternate(autA, autB), capA ++ capB)
         }
         case IFunApp(`re_inter`, Seq(a, b)) => {
           throw new IllegalArgumentException(
@@ -362,57 +456,43 @@ class Regex2PFA(theory : OstrichStringTheory) {
         case IFunApp(`re_*`, Seq(a)) => {
           val (autA, capA) = buildPatternImpl(a)
 
-          val localStarNum = numStar
-          numStar += 1
-          starInfo(localStarNum) = (autA.initial, autA.accepting, capA)
-
-          (PFA.star(autA), capA)
+          (builder.star(autA), capA)
         }
         case IFunApp(`re_*?`, Seq(a)) => {
           val (autA, capA) = buildPatternImpl(a)
 
-          val localStarNum = numStar
-          numStar += 1
-          starInfo(localStarNum) = (autA.initial, autA.accepting, capA)
-
-          (PFA.lazystar(autA), capA)
+          (builder.lazystar(autA), capA)
         }
         case IFunApp(`re_+`, Seq(a)) => {
           val (autA, capA) = buildPatternImpl(a)
 
-          val localStarNum = numStar
-          numStar += 1 // plus is regarded as a star
-          starInfo(localStarNum) = (autA.initial, autA.accepting, capA)
-
-          (PFA.plus(autA), capA)
+          (builder.plus(autA), capA)
         }
         case IFunApp(`re_+?`, Seq(a)) => {
           val (autA, capA) = buildPatternImpl(a)
 
-          val localStarNum = numStar
-          numStar += 1 // plus is regarded as a star
-          starInfo(localStarNum) = (autA.initial, autA.accepting, capA)
-
-          (PFA.lazyplus(autA), capA)
+          (builder.lazyplus(autA), capA)
         }
         case IFunApp(`re_opt`, Seq(a)) => {
           val (autA, capA) = buildPatternImpl(a)
-          (PFA.optional(autA), capA)
+          (builder.optional(autA), capA)
         }
         case IFunApp(`re_loop`, Seq(IIntLit(n1), IIntLit(n2), a)) => {
           val (autA, capA) = buildPatternImpl(a)
           if (capA.isEmpty) {
-            var aut = PFA.none
+            // too inefficient
+            // maybe there's some other way
+            var aut = builder.none
             var i = n1
             while (i <= n2) {
               var j = 0
-              var disjunct = PFA.epsilon
+              var disjunct = builder.epsilon
               while (j < i) {
                 val (copy, _) = buildPatternImpl(a)
-                disjunct = PFA.concat(copy, disjunct)
+                disjunct = builder.concat(copy, disjunct)
                 j = j + 1
               }
-              aut = PFA.alternate(disjunct, aut)
+              aut = builder.alternate(disjunct, aut)
               i = i + 1
             }
             (aut, capA)
@@ -442,20 +522,27 @@ class Regex2PFA(theory : OstrichStringTheory) {
           for ((s, trans) <- autA.sTran; (lbl, tgt) <- trans) {
             capState.addBinding(localCaptureNum, tgt)
             capState.addBinding(localCaptureNum, s)
+            stateCap.addBinding(tgt, localCaptureNum)
+            stateCap.addBinding(s, localCaptureNum)
           }
           for ((s, trans) <- autA.preTran; tgt <- trans) {
             capState.addBinding(localCaptureNum, s)
             capState.addBinding(localCaptureNum, tgt)
+            stateCap.addBinding(tgt, localCaptureNum)
+            stateCap.addBinding(s, localCaptureNum)
           }
           for ((s, trans) <- autA.postTran; tgt <- trans) {
             capState.addBinding(localCaptureNum, s)
             capState.addBinding(localCaptureNum, tgt)
+            stateCap.addBinding(tgt, localCaptureNum)
+            stateCap.addBinding(s, localCaptureNum)
           }
+          capInit.addBinding(localCaptureNum, autA.initial)
 
           (autA, capA + localCaptureNum)
         }
         case IFunApp(`str_to_re`, Seq(a)) => {
-          (PFA.constant(StringTheory.term2List(a)), Set())
+          (builder.constant(StringTheory.term2List(a)), Set())
         }
         case IFunApp(`re_from_ecma2020`, Seq(a)) => {
           val parser = new ECMARegexParser(theory)
@@ -470,29 +557,14 @@ class Regex2PFA(theory : OstrichStringTheory) {
     }
 
     val (aut, _) = buildPatternImpl(simplifier(pat))
-    val state2Capture_mut = new MHashMap[State, MSet[Int]] with MMultiMap[State, Int]
 
-    for ((cap, states) <- capState;
-         s <- states) {
-        state2Capture_mut.addBinding(s, cap)
-    }
-
-    val state2Capture = (for ((s, caps) <- state2Capture_mut)
+    val state2Capture = (for ((s, caps) <- Regex2PFA.stateCap)
       yield (s, caps.toSet)).toMap
 
-    val states2Star_mut = new MHashMap[(State, State), MSet[Int]] with MMultiMap[(State, State), Int]
-    val star2Capture = starInfo.map({
-      case (starnum, (_, _, caps)) => (starnum, caps)
-    }).toMap
+    val cap2Init = (for ((cap, inits) <- Regex2PFA.capInit)
+      yield (cap, inits.toSet)).toMap
 
-    for ((starnum, (start, end, _)) <- starInfo) {
-      states2Star_mut.addBinding((end, start), starnum)
-    }
-
-    val states2Star = (for ((s, star) <- states2Star_mut)
-      yield (s, star.toSet)).toMap
-
-    (aut, numCapture, numStar, state2Capture, states2Star, star2Capture)
+    (aut, numCapture, state2Capture, cap2Init)
   }
 
   private def buildReplacementRegex(t : ITerm) : Seq[UpdateOp] = {
@@ -519,28 +591,6 @@ class Regex2PFA(theory : OstrichStringTheory) {
         throw new IllegalArgumentException(
           "could not use " + t + " in the replacement string")
     }
-  }
-
-  def buildReplaceInfo(pat : ITerm, rep: ITerm) : (completeInfo, Seq[UpdateOp]) = {
-    capNumTransform.clear
-    val info = buildPatternRegex(pat)
-    val ops = buildReplacementRegex(rep)
-
-    (info, ops)
-  }
-
-  def buildExtractInfo(index: Int, pat: ITerm) : (Int, completeInfo) = {
-    capNumTransform.clear
-
-    val info = buildPatternRegex(pat)
-    val localindex =
-      (capNumTransform get index) match {
-        case None =>
-          throw new IllegalArgumentException("Undefined capture group referenced: " + index)
-        case Some(l) => l
-      }
-
-    (localindex, info)
   }
 
 }

--- a/src/main/scala/ostrich/PrioStreamingTransducer.scala
+++ b/src/main/scala/ostrich/PrioStreamingTransducer.scala
@@ -657,12 +657,12 @@ extends StreamingTransducer {
       for (arrow <- pre) {
         val (op, prio, dest) = arrow
         sb.append(state + " -> " + dest);
-        sb.append("[label=\"epsilon /" + prio + "\"];\n")
+        sb.append("[label=\"epsilon /" + prio + "/" + op + "\"];\n")
       }
       for (arrow <- post) {
         val (op, prio, dest) = arrow
         sb.append(state + " -> " + dest);
-        sb.append("[label=\"epsilon /" + prio + "\"];\n")
+        sb.append("[label=\"epsilon /" + prio + "/" + op + "\"];\n")
       }
     }
 

--- a/src/main/scala/ostrich/PrioStreamingTransducer.scala
+++ b/src/main/scala/ostrich/PrioStreamingTransducer.scala
@@ -138,17 +138,15 @@ extends StreamingTransducer {
     // input index to process next,
     // prohibition set of epsilon transitions,
     // string variable values,
-    // is begin anchor consumed?
-    // is end anchor consumed?
-    val worklist = new MStack[(State, Int, Set[(State, State)], Seq[String], Boolean, Boolean)]
+    val worklist = new MStack[(State, Int, Set[(State, State)], Seq[String])]
 
-    worklist.push((initialState, 0, Set.empty[(State, State)], emptyVal, false, false))
+    worklist.push((initialState, 0, Set.empty[(State, State)], emptyVal))
 
     // find the output by dfs,
     // push configurations to stack by priority,
     // configuration with highest priority is pushed last thus processed first
     while (!worklist.isEmpty) {
-      val (s, pos, blocked, values, beginMatched, endMatched) = worklist.pop
+      val (s, pos, blocked, values) = worklist.pop
 
       if (pos >= input.size && isAccept(s))
         return Some(evalUpdateOps(values, acceptingStates.get(s).get, (o) => ""))
@@ -165,7 +163,7 @@ extends StreamingTransducer {
               val tOps = operation(t)
               val valueNext = getNewVal(values, tOps, (o) => "")
               val bnext = blocked ++ Set((s, snext))
-              worklist.push((snext, pnext, bnext, valueNext, beginMatched, endMatched))
+              worklist.push((snext, pnext, bnext, valueNext))
             }
           }
 
@@ -181,7 +179,7 @@ extends StreamingTransducer {
                   if (BricsTLabelOps.labelContains(inc, lbl)) {
                     val tOps = operation(t)
                     val valueNext = getNewVal(values, tOps, (o) => (inc + o).toChar.toString)
-                    worklist.push((snext, pnext, Set.empty[(State, State)], valueNext, beginMatched, endMatched))
+                    worklist.push((snext, pnext, Set.empty[(State, State)], valueNext))
                   }
                 }
               }
@@ -197,12 +195,12 @@ extends StreamingTransducer {
                 // this is crucial for regex like 'a|^b'
 
                 val pnext = pos
-                if (!beginMatched && pos == 0) {
+                if (pos == 0) {
                   val tOps = operation(t)
                   // ^ is not a real char, exclude it in capture groups
                   val valueNext = getNewVal(values, tOps, (o) => "")
                   // we assume ^ and $ resets the blocked set:
-                  worklist.push((snext, pnext, Set.empty[(State, State)], valueNext, true, endMatched))
+                  worklist.push((snext, pnext, Set.empty[(State, State)], valueNext))
                 }
               }
               case EndAnchor => {
@@ -218,11 +216,11 @@ extends StreamingTransducer {
                 // Also, after the match of $, it is still possible to take
                 // several (only) epsilon transitions before halting.
                 // like when regex is 'b | c$'
-                if (!endMatched && pos == input.size) {
+                if (pos == input.size) {
                   val tOps = operation(t)
                   // $ is not a real char, exclude it in capture groups
                   val valueNext = getNewVal(values, tOps, (o) => "")
-                  worklist.push((snext, pnext, Set.empty[(State, State)], valueNext, beginMatched, true))
+                  worklist.push((snext, pnext, Set.empty[(State, State)], valueNext))
                 }
               }
             }
@@ -236,7 +234,7 @@ extends StreamingTransducer {
               val tOps = operation(t)
               val valueNext = getNewVal(values, tOps, (o) => "")
               val bnext = blocked ++ Set((s, snext))
-              worklist.push((snext, pnext, bnext, valueNext, beginMatched, endMatched))
+              worklist.push((snext, pnext, bnext, valueNext))
             }
           }
 
@@ -317,8 +315,8 @@ extends StreamingTransducer {
     // trace
     // prohibition set
     // blocked e-transition
-    // ^ allowed?
-    // $ allowed?
+    // ^ allowed? => sigma trans. happened
+    // $ occurred? => no sigma trans. allowed
     // state of preimage aut to add new transitions from
     val worklist = new MStack[(State,
                                Trace,
@@ -330,13 +328,13 @@ extends StreamingTransducer {
 
     // transducer state, trace, automaton state set
     def getState(ts : State, tr : Trace, as : ProhibitionSet, bs : Set[(State, State)],
-      beginAllowed : Boolean, endAllowed : Boolean) = {
-      sMapRev.getOrElseUpdate((ts, tr, as, bs, beginAllowed, endAllowed), {
+      beginAllowed : Boolean, endOccurred : Boolean) = {
+      sMapRev.getOrElseUpdate((ts, tr, as, bs, beginAllowed, endOccurred), {
         val ps = preBuilder.getNewState
-        // bs, beginAllowed and endAllowed only restricts the run,
+        // bs, beginAllowed and endOccurred only restricts the run,
         // they are irrelevant to the acceptance of a run.
         preBuilder.setAccept(ps, isAcceptingPreState(ts, tr, as))
-        worklist.push((ts, tr, as, bs, beginAllowed, endAllowed, ps))
+        worklist.push((ts, tr, as, bs, beginAllowed, endOccurred, ps))
         ps
       })
     }
@@ -344,7 +342,7 @@ extends StreamingTransducer {
     val newInitState = getState(initialState, initTrace,
       Set.empty[(State, Boolean, Boolean)],
       Set.empty[(State, State)],
-      true, true)
+      true, false)
     preBuilder setInitialState newInitState
 
     // collect silent transitions during main loop and eliminate them after
@@ -460,7 +458,7 @@ extends StreamingTransducer {
     while (!worklist.isEmpty) {
       ap.util.Timeout.check
 
-      val (ts, tr, blocked, etrans, beginAllowed, endAllowed, ps) = worklist.pop()
+      val (ts, tr, blocked, etrans, beginAllowed, endOccurred, ps) = worklist.pop()
 
       (lblTrans get ts) match {
         case None => // nothing
@@ -472,40 +470,43 @@ extends StreamingTransducer {
             val newBlocked = blocked ++ epsClosure(
               (for ((_, priority2, s) <- pre.iterator;
                 if (priority2 > priority) && !etrans.contains((ts, s)) )
-                  yield (s, beginAllowed, endAllowed)), etrans)
+                  yield (s, beginAllowed, endOccurred)), etrans)
             val newEtrans = etrans ++ Set((ts, nextState))
 
             // epsilon transitions does not alter anchor usability status.
-            silentTransitions.addBinding(ps, getState(nextState, newTrace, newBlocked, newEtrans, beginAllowed, endAllowed))
+            silentTransitions.addBinding(ps, getState(nextState, newTrace, newBlocked, newEtrans, beginAllowed, endOccurred))
           }
 
           // if the end anchor $ is already matched, it signifies the end of the run!
           // thus only when endAllowed is true, sigma transitions are allowed.
-          if (endAllowed) {
+          //if (endAllowed) {
+
             // sigma transitions
             for ((l, ops, priority, nextState) <- transitions) {
               l match {
                 case NormalLabel(lbl) => {
+                  if (!endOccurred) {
+                    val preBlock = blocked ++ epsClosure(
+                      (for ((_, _, s) <- pre.iterator)
+                        yield (s, beginAllowed, endOccurred)), etrans)
 
-                  val preBlock = blocked ++ epsClosure(
-                    (for ((_, _, s) <- pre.iterator)
-                      yield (s, beginAllowed, endAllowed)), etrans)
-
-                  for (nlbl <- splitLabels(lbl, findOffset(ops), preBlock, priority, transitions); if BricsTLabelOps.isNonEmptyLabel(nlbl)) {
-                    // nlbl : (Char, Char)
-                    val newTrace = getNewTrace(tr, ops, (o) => {
-                      offsetTraceCache.getOrElseUpdate((nlbl, o), {
-                        (for (s <- aut.states;
-                              (target, lbl) <- aut.outgoingTransitions(s);
-                              shiftLbl = aut.LabelOps.shift(lbl, -o);
-                              if aut.LabelOps.labelsOverlap(shiftLbl, nlbl.asInstanceOf[aut.TLabel]))
-                              yield (s, target)).toSet
+                    for (nlbl <- splitLabels(lbl, findOffset(ops), preBlock, priority, transitions); if BricsTLabelOps.isNonEmptyLabel(nlbl)) {
+                      // nlbl : (Char, Char)
+                      val newTrace = getNewTrace(tr, ops, (o) => {
+                        offsetTraceCache.getOrElseUpdate((nlbl, o), {
+                          (for (s <- aut.states;
+                                (target, lbl) <- aut.outgoingTransitions(s);
+                                shiftLbl = aut.LabelOps.shift(lbl, -o);
+                                if aut.LabelOps.labelsOverlap(shiftLbl, nlbl.asInstanceOf[aut.TLabel]))
+                                yield (s, target)).toSet
+                        })
                       })
-                    })
-                    val newBlocked = postStates(preBlock, nlbl, priority, transitions)
-                    preBuilder.addTransition(ps,
-                                          nlbl.asInstanceOf[aut.TLabel],
-                                          getState(nextState, newTrace, newBlocked, Set.empty[(State, State)], false, endAllowed)) // sigma transition always disable the start anchor ^
+                      val newBlocked = postStates(preBlock, nlbl, priority, transitions)
+                      preBuilder.addTransition(ps,
+                                            nlbl.asInstanceOf[aut.TLabel],
+                                            getState(nextState, newTrace, newBlocked, Set.empty[(State, State)], false, endOccurred)) // sigma transition always disable the start anchor ^
+
+                    }
                   }
                 }
                 case BeginAnchor => {
@@ -517,43 +518,43 @@ extends StreamingTransducer {
                     // should ^ and $ be considered as epsilon transitions when
                     // computing the blocked set???
                     val itr = (for ((_, _, s) <- pre.iterator)
-                      yield (s, beginAllowed, endAllowed)) ++
+                      yield (s, true, endOccurred)) ++
                     (for ((lbl, _, priority2, s) <- transitions; if lbl == BeginAnchor && priority2 > priority)
-                      yield (s, false, endAllowed))
+                      yield (s, true, endOccurred))
 
                     val preBlock = blocked ++ epsClosure(itr, etrans)
-                    silentTransitions.addBinding(ps, getState(nextState, newTrace, preBlock, Set.empty[(State, State)], false, endAllowed))
+                    silentTransitions.addBinding(ps, getState(nextState, newTrace, preBlock, Set.empty[(State, State)], true, endOccurred))
                   }
                 }
                 case EndAnchor => {
                   // likewise for $
                   val newTrace = getNewTrace(tr, ops, (o) => defaultTrace)
                   val itr = (for ((_, _, s) <- pre.iterator)
-                    yield (s, beginAllowed, endAllowed)) ++
+                    yield (s, beginAllowed, endOccurred)) ++
                   (for ((lbl, _, priority2, s) <- transitions; if lbl == EndAnchor && priority2 > priority)
-                    yield (s, false, false))
+                    yield (s, beginAllowed, true))
 
                   val preBlock = blocked ++ epsClosure(itr, etrans)
-                  silentTransitions.addBinding(ps, getState(nextState, newTrace, preBlock, Set.empty[(State, State)], false, false)) // $ disables both ^ and $
+                  silentTransitions.addBinding(ps, getState(nextState, newTrace, preBlock, Set.empty[(State, State)], beginAllowed, true)) // $ disables sigma
                 }
               }
             }
-          }
+         
 
           // the postfix group of epsilon transitions
           for ((ops, priority, nextState) <- post; if !etrans.contains((ts, nextState))) {
             val newTrace = getNewTrace(tr, ops, (o) => defaultTrace)
             val itr : Iterator[(State, Boolean, Boolean)] =
               (for ((_, _, s) <- pre; if !etrans.contains((ts, s)))
-                  yield (s, beginAllowed, endAllowed)).iterator ++
+                  yield (s, beginAllowed, endOccurred)).iterator ++
               (for ((_, priority2, s) <- post;
                 if (priority2 > priority) && !etrans.contains((ts, s)) )
-                  yield (s, beginAllowed, endAllowed))
+                  yield (s, beginAllowed, endOccurred))
 
-            val newBlocked : ProhibitionSet = blocked ++ epsClosure(itr, etrans) ++ Set((ts, beginAllowed, endAllowed))
+            val newBlocked : ProhibitionSet = blocked ++ epsClosure(itr, etrans) ++ Set((ts, beginAllowed, endOccurred))
             val newEtrans = etrans ++ Set((ts, nextState))
 
-            silentTransitions.addBinding(ps, getState(nextState, newTrace, newBlocked, newEtrans, beginAllowed, endAllowed))
+            silentTransitions.addBinding(ps, getState(nextState, newTrace, newBlocked, newEtrans, beginAllowed, endOccurred))
           }
         }
       }
@@ -575,7 +576,8 @@ extends StreamingTransducer {
                          trans: Iterable[SigmaTransition]) : ProhibitionSet = {
       val targetStates =
         // 'advance' the old blocked states with 'label'
-        (for ((s, _, end) <- states.iterator; if end;
+        // only consider trace where $ has not occurred
+        (for ((s, _, endOccurred) <- states.iterator; if !endOccurred;
               (_, transitions, _) <- (lblTrans get s).iterator;
               (sLabel, _, _, target) <- transitions.iterator;
               l <- LabelOps.weaken(sLabel).iterator;
@@ -583,13 +585,13 @@ extends StreamingTransducer {
                 // ^ is always disabled by a sigma transition
                 // as for $, it is guaranteed to be enabled, otherwise
                 // current transition is impossible
-         yield (target, false, true)) ++
+         yield (target, false, false)) ++
         // add new blocked states
         (for ((l, _, priority2, s) <- trans;
           lbl <- LabelOps.weaken(l).iterator;
           if (priority2 > priority)
           && BricsTLabelOps.labelsOverlap(lbl, label))
-          yield (s, false, true)) //likewise
+          yield (s, false, false)) //likewise
       (epsClosure(targetStates, Set.empty[(State, State)]))
     }
 
@@ -602,15 +604,15 @@ extends StreamingTransducer {
         todo push s
 
     while (!todo.isEmpty) {
-      val (s, beginAllowed, endAllowed) = todo.pop
+      val (s, beginAllowed, endOccurred) = todo.pop
       for ((pre, transitions, post) <- (lblTrans get s).iterator) {
         for ((_, _, t) <- pre; if !Lambda.contains((s, t))) {
-          val ts = (t, beginAllowed, endAllowed)
+          val ts = (t, beginAllowed, endOccurred)
           if (res add ts)
             todo push ts
         }
         for ((_, _, t) <- post; if !Lambda.contains((s, t))) {
-          val ts = (t, beginAllowed, endAllowed)
+          val ts = (t, beginAllowed, endOccurred)
           if (res add ts)
             todo push ts
         }
@@ -618,17 +620,15 @@ extends StreamingTransducer {
           lbl match {
             case BeginAnchor => {
               if (beginAllowed) {
-                val ts = (s, false, endAllowed)
+                val ts = (s, true, endOccurred)
                 if (res add ts)
                   todo push ts
               }
             }
             case EndAnchor => {
-              if (endAllowed) {
-                val ts = (s, false, false)
-                if (res add ts)
-                  todo push ts
-              }
+              val ts = (s, beginAllowed, true)
+              if (res add ts)
+                todo push ts
             }
             case _ =>
           }

--- a/src/main/scala/ostrich/ReplaceCGPreOp.scala
+++ b/src/main/scala/ostrich/ReplaceCGPreOp.scala
@@ -45,13 +45,13 @@ import dk.brics.automaton.{Automaton => BAutomaton,
 
 object ReplaceCGPreOp {
 
-  import PFA.completeInfo
+  import Regex2PFA.completeInfo
 
   def apply(pat : completeInfo, rep : Seq[UpdateOp]) : PreOp = 
     StreamingTransducerPreOp(buildPSST(pat, rep))
 
   def buildPSST(pat : completeInfo, rep : Seq[UpdateOp]) : PrioStreamingTransducer = {
-    val (aut, numCap, numStar, state2Caps, states2Stars, star2Caps) = pat
+    val (aut, numCap, state2Caps, cap2Init) = pat
 
     // for each capture group, we have a string variable.
     // Besides, we have a special variable 'res' for the result, indexed by 'numCap'
@@ -117,29 +117,29 @@ object ReplaceCGPreOp {
     val opCache = new MHashMap[(autState, autState), Seq[Seq[UpdateOp]]]
 
     def getOps(current : autState, next: autState) = {
-      opCache.getOrElseUpdate((current, next), {
-        // we have to consider which Klenne Stars are reset
-        // and how variables are thus updated
-        val caps_activated = state2Caps.getOrElse(next, Set())
-        val stars_reset : Set[Int] = states2Stars.getOrElse((current, next), Set.empty[Int])
-        val caps_in_stars : Set[Int] =
-          (for (star <- stars_reset; starcaps = (star2Caps.getOrElse(star, Set()));
-            cap <- starcaps) yield cap).toSet
+      val caps_activated = state2Caps.getOrElse(next, Set())
+      val caps_activated_old = state2Caps.getOrElse(current, Set())
 
-        val ops : Seq[Seq[UpdateOp]] = updateWithIndex {
-          index => {
-            val is_activated = caps_activated contains index
-            val is_in_stars = caps_in_stars contains index
-            (is_activated, is_in_stars) match {
-              case (true, true) => single
-              case (true, false) => append_after(index)
-              case (false, true) => clear
-              case (false, false) => nochange(index)
+      val ops : Seq[Seq[UpdateOp]] = updateWithIndex {
+        index => {
+          val is_activated = caps_activated contains index
+          val is_activated_old = caps_activated_old contains index
+          if (is_activated && is_activated_old) {
+            // now check inital states:
+            val caps_initials = cap2Init.getOrElse(index, Set())
+            val is_initial = caps_initials contains current
+            if (is_initial) {
+              clear
+            } else {
+              append_after(index)
             }
+          } else {
+            // `index` is not relevant here
+            nochange(index)
           }
         }
-        ops
-      })
+      }
+      ops
     }
 
     // dfs
@@ -166,15 +166,27 @@ object ReplaceCGPreOp {
       }
     }
 
-    val tranEnd = getState(aut.accepting)
-    builder.addPreETransition(tranEnd, updateWithIndex(o => {
-      if (o == numCap) {
-        List(RefVariable(numCap)) ++ rep
-      } else {
-        clear
-      }
-    }), qf)
-
+    val (f1, f2) = aut.accepting
+    for (s <- f1) {
+      val tranEnd = getState(s)
+      builder.addPreETransition(tranEnd, updateWithIndex(o => {
+        if (o == numCap) {
+          List(RefVariable(numCap)) ++ rep
+        } else {
+          clear
+        }
+      }), qf)
+    }
+    for (s <- f2) {
+      val tranEnd = getState(s)
+      builder.addPreETransition(tranEnd, updateWithIndex(o => {
+        if (o == numCap) {
+          List(RefVariable(numCap)) ++ rep
+        } else {
+          clear
+        }
+      }), qf)
+    }
     val tran = builder.getTransducer
     tran
   }

--- a/src/test/scala/SMTLIBTests.scala
+++ b/src/test/scala/SMTLIBTests.scala
@@ -97,6 +97,10 @@ object SMTLIBTests extends Properties("SMTLIBTests") {
     checkFile("tests/anchor-7.smt2", "sat")
   property("anchor-8.smt2") =
     checkFile("tests/anchor-8.smt2", "sat")
+  property("anchor-double.smt2") =
+    checkFile("tests/anchor-double.smt2", "sat")
+  property("anchor-alternate.smt2") =
+    checkFile("tests/anchor-alternate.smt2", "sat")
 
   property("regex_cg.smt2") =
     checkFile("tests/regex_cg.smt2", "sat")

--- a/tests/anchor-alternate.smt2
+++ b/tests/anchor-alternate.smt2
@@ -1,0 +1,21 @@
+(set-option :produce-models true)
+(set-option :inline-size-limit 10000)
+
+(declare-const var0 String)
+(assert (str.in.re
+          (str.replace_cg_all var0
+                              (re.++
+                                re.begin-anchor
+                                re.begin-anchor
+                                (re.opt
+                                  ((_ re.capture 1)
+                                   (re.range "a" "a")))
+                                (re.range "a" "a")
+                                re.end-anchor
+                                re.begin-anchor
+                                re.end-anchor)
+                              (_ re.reference 1))
+          (re.* (re.range "a" "a"))))
+
+(check-sat)
+(get-model)

--- a/tests/anchor-double.smt2
+++ b/tests/anchor-double.smt2
@@ -1,0 +1,20 @@
+(set-option :produce-models true)
+(set-option :inline-size-limit 10000)
+
+(declare-const var0 String)
+(assert (str.in.re
+          (str.replace_cg_all var0
+                              (re.++
+                                re.begin-anchor
+                                re.begin-anchor
+                                (re.opt
+                                  ((_ re.capture 1)
+                                   (re.range "a" "a")))
+                                (re.range "a" "a")
+                                re.end-anchor
+                                re.end-anchor)
+                              (_ re.reference 1))
+          (re.range "a" "a")))
+
+(check-sat)
+(get-model)

--- a/tests/js-semantics.smt2
+++ b/tests/js-semantics.smt2
@@ -1,0 +1,12 @@
+(set-option :produce-models true)
+(set-option :inline-size-limit 10000)
+
+(declare-const var0 String)
+(declare-const y String)
+(assert (= var0 "abb"))
+(assert (= y
+          ((_ str.extract 1) var0 (re.+ ((_ re.capture 1) (re.*? re.allchar))))))
+(assert (= y "b"))
+
+(check-sat)
+(get-model)


### PR DESCRIPTION
This PR changes the old semantics (which is more like Python) to a new one resembling javascript.

I did some refactor so that the  semantic behavior of PFA can be changed by modifying line 104 of OstrichSolver.scala

There are two builder available in PFA.scala. In case a new semantics is intended, we just need to inherit and implement the abstract `PFAbuilder` class.