### PR TITLE
Consider whole alphabet when constructing Caley graph

### DIFF
--- a/src/main/scala/ostrich/automata/BricsAutomaton.scala
+++ b/src/main/scala/ostrich/automata/BricsAutomaton.scala
@@ -363,27 +363,31 @@ class BricsTLabelEnumerator(labels: Iterator[(Char, Char)])
   }
 
   private def calculateDisjointLabelsComplete() : List[(Char, Char)] = {
-    val labelsComp = disjointLabels.foldRight(List[(Char, Char)]()) {
-      case ((min, max), Nil) => {
-        // using Char.MaxValue since we include internal chars
-        if (max < Char.MaxValue)
-          List((min,max), ((max + 1).toChar, Char.MaxValue))
-        else
-          List((min, max))
-      }
-      case ((min, max), (minLast, maxLast)::lbls) => {
-        val minLastPrev = (minLast - 1).toChar
-        if (max < minLastPrev)
-          (min, max)::((max + 1).toChar, minLastPrev)::(minLast, maxLast)::lbls
-        else
-          (min, max)::(minLast, maxLast)::lbls
-      }
-    }
-    if (Char.MinValue < labelsComp.head._1) {
-      val nextMin = (labelsComp.head._1 - 1).toChar
-      (Char.MinValue, nextMin)::labelsComp
+    if (disjointLabels.isEmpty) {
+      List((Char.MinValue, Char.MaxValue))
     } else {
-      labelsComp
+      val labelsComp = disjointLabels.foldRight(List[(Char, Char)]()) {
+        case ((min, max), Nil) => {
+          // using Char.MaxValue since we include internal chars
+          if (max < Char.MaxValue)
+            List((min,max), ((max + 1).toChar, Char.MaxValue))
+          else
+            List((min, max))
+        }
+        case ((min, max), (minLast, maxLast)::lbls) => {
+          val minLastPrev = (minLast - 1).toChar
+          if (max < minLastPrev)
+            (min, max)::((max + 1).toChar, minLastPrev)::(minLast, maxLast)::lbls
+          else
+            (min, max)::(minLast, maxLast)::lbls
+        }
+      }
+      if (Char.MinValue < labelsComp.head._1) {
+        val nextMin = (labelsComp.head._1 - 1).toChar
+        (Char.MinValue, nextMin)::labelsComp
+      } else {
+        labelsComp
+      }
     }
   }
 }

--- a/src/main/scala/ostrich/automata/CaleyGraph.scala
+++ b/src/main/scala/ostrich/automata/CaleyGraph.scala
@@ -174,7 +174,7 @@ object CaleyGraph {
       : Map[Box[A], Iterable[A#TLabel]] = {
     val ae = aut.labelEnumerator
     val boxes : Map[A#TLabel,Box[A]] =
-      ae.enumDisjointLabels.map(i => i -> new Box[A])(collection.breakOut)
+      ae.enumDisjointLabelsComplete.map(i => i -> new Box[A])(collection.breakOut)
 
     for ((q1, i, q2) <- aut.transitions;
          i2 <- ae.enumLabelOverlap(i))

--- a/src/test/scala/SMTLIBTests.scala
+++ b/src/test/scala/SMTLIBTests.scala
@@ -428,5 +428,6 @@ object SMTLIBTests extends Properties("SMTLIBTests") {
     checkFile("tests/concat-empty.smt2", "unsat")
   property("replace-bug.smt2") =
     checkFile("tests/replace-bug.smt2", "unsat")
-
+  property("bug-56-replace-bug2.smt2") =
+    checkFile("tests/bug-56-replace-bug2.smt2", "sat")
 }

--- a/src/test/scala/ostrich/automata/CaleyGraphSpecification.scala
+++ b/src/test/scala/ostrich/automata/CaleyGraphSpecification.scala
@@ -75,7 +75,8 @@ object CaleyGraphSpecification
     val aut = new BAutomaton
     val q = aut.getInitialState
     val baut = new BricsAutomaton(aut)
-    caleyGraphHasBoxes(baut, Set(Box[BricsAutomaton]((q, q))))
+    val nodes = Set(Box[BricsAutomaton](), Box[BricsAutomaton]((q, q)))
+    caleyGraphHasBoxes(baut, nodes)
   }
 
   property("Caley graph nodes for q0 -a-> q1 -b-> q2") = {

--- a/tests/bug-56-replace-bug2.smt2
+++ b/tests/bug-56-replace-bug2.smt2
@@ -1,0 +1,11 @@
+(set-logic QF_S)
+
+(declare-fun x_4 () String)
+(declare-fun sigmaStar_0 () String)
+
+(assert (= x_4 (str.replace sigmaStar_0 "ab" "c")))
+
+(assert (str.in_re x_4 (str.to_re "aa")))
+
+(check-sat)
+(get-model)


### PR DESCRIPTION
If only characters from the automaton are used, the empty box might be missing. (I.e. [w] for all w that don't connect any states.)

This includes fixing the case where an automaton has no characters, but the complete disjoint set was empty instead of (minVal, maxVal).

Add test case for reported bug and corrected test case for Caley graph of empty automaton (that was missing the empty box).

Fixes #56