### PR TITLE
Don't prevent rematch in replace transducer

### DIFF
--- a/src/main/scala/ostrich/preop/ReplacePreOp.scala
+++ b/src/main/scala/ostrich/preop/ReplacePreOp.scala
@@ -264,11 +264,11 @@ object ReplacePreOpRegEx {
         }
         case EndMatch(frontier) => {
           for (lbl <- labels) {
-            val initImg = aut.getImage(autInit, lbl)
             val frontImg = aut.getImage(frontier, lbl)
             val noreachImg = aut.getImage(noreach, lbl)
 
-            val noMatch = getState(CopyRest, initImg ++ frontImg ++ noreachImg)
+            val noMatch = getState(CopyRest, frontImg ++ noreachImg)
+
             builder.addTransition(ts, lbl, copy, noMatch)
           }
         }

--- a/src/test/scala/SMTLIBTests.scala
+++ b/src/test/scala/SMTLIBTests.scala
@@ -430,4 +430,6 @@ object SMTLIBTests extends Properties("SMTLIBTests") {
     checkFile("tests/replace-bug.smt2", "unsat")
   property("bug-56-replace-bug2.smt2") =
     checkFile("tests/bug-56-replace-bug2.smt2", "sat")
+  property("bug-58-replace-re") =
+    checkFile("tests/bug-58-replace-re.smt2", "sat")
 }

--- a/tests/bug-58-replace-re.smt2
+++ b/tests/bug-58-replace-re.smt2
@@ -1,0 +1,4 @@
+(define-fun sigmaStar_048 () String "Ajavascript:")
+(define-fun x_7 () String "javascript:")
+(assert (= x_7 (str.replace_re sigmaStar_048 re.allchar "") ) )
+(check-sat)


### PR DESCRIPTION
When creating the transducer for a regex, after a match has finished, initImg was used to prevent the regex immediately matching again. This is not needed (after a single match, anything is accepted in replace).

Looks like a bad copy/paste/fix from replaceall where the case of an immediate second match after one match has ended needed special care.

Fixes #58