### PR TITLE
Fix bugs and make replace(all) operations SMT-LIB compliant

### DIFF
--- a/src/main/scala/ostrich/OstrichStringFunctionTranslator.scala
+++ b/src/main/scala/ostrich/OstrichStringFunctionTranslator.scala
@@ -1,21 +1,21 @@
 /**
  * This file is part of Ostrich, an SMT solver for strings.
  * Copyright (c) 2018-2021 Matthew Hague, Philipp Ruemmer. All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * * Redistributions of source code must retain the above copyright notice, this
  *   list of conditions and the following disclaimer.
- * 
+ *
  * * Redistributions in binary form must reproduce the above copyright notice,
  *   this list of conditions and the following disclaimer in the documentation
  *   and/or other materials provided with the distribution.
- * 
+ *
  * * Neither the name of the authors nor the names of their
  *   contributors may be used to endorse or promote products derived from
  *   this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -71,21 +71,21 @@ class OstrichStringFunctionTranslator(theory : OstrichStringTheory,
                     str_at, str_at_right, str_trim) ++
                theory.extraFunctionPreOps.keys)
      yield FunPred(f)) ++ theory.transducerPreOps.keys
-  
+
   def apply(a : Atom) : Option[(() => PreOp, Seq[Term], Term)] = a.pred match {
     case FunPred(`str_++`) =>
       Some((() => ConcatPreOp, List(a(0), a(1)), a(2)))
     case FunPred(`str_replaceall`) if strDatabase isConcrete a(1) => {
       val op = () => {
         val b = strDatabase term2ListGet a(1)
-        ReplaceAllPreOp(b map (_.toChar))
+        ReplaceAllShortestPreOp(b map (_.toChar))
       }
       Some((op, List(a(0), a(2)), a(3)))
     }
     case FunPred(`str_replace`) if strDatabase isConcrete a(1) => {
       val op = () => {
         val b = strDatabase term2ListGet a(1)
-        ReplacePreOp(b map (_.toChar))
+        ReplaceShortestPreOp(b map (_.toChar))
       }
       Some((op, List(a(0), a(2)), a(3)))
     }
@@ -93,7 +93,7 @@ class OstrichStringFunctionTranslator(theory : OstrichStringTheory,
       for (regex <- regexAsTerm(a(1))) yield {
         val op = () => {
           val aut = autDatabase.regex2Automaton(regex).asInstanceOf[AtomicStateAutomaton]
-          ReplaceAllPreOp(aut)
+          ReplaceAllLongestPreOp(aut)
         }
         (op, List(a(0), a(2)), a(3))
       }
@@ -101,7 +101,7 @@ class OstrichStringFunctionTranslator(theory : OstrichStringTheory,
       for (regex <- regexAsTerm(a(1))) yield {
         val op = () => {
           val aut = autDatabase.regex2Automaton(regex).asInstanceOf[AtomicStateAutomaton]
-          ReplacePreOp(aut)
+          ReplaceLongestPreOp(aut)
         }
         (op, List(a(0), a(2)), a(3))
       }

--- a/src/main/scala/ostrich/preop/NOPPreOp.scala
+++ b/src/main/scala/ostrich/preop/NOPPreOp.scala
@@ -1,0 +1,66 @@
+/**
+ * This file is part of Ostrich, an SMT solver for strings.
+ * Copyright (c) 2018 Matthew Hague, Philipp Ruemmer. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the authors nor the names of their
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package ostrich.preop
+
+import ostrich.automata.{Automaton, AtomicStateAutomaton, ProductAutomaton}
+
+/**
+ * Pre-Op for the No-op function.
+ */
+object NOPPreOp extends PreOp {
+  override def toString = "nop"
+
+  def apply(argumentConstraints : Seq[Seq[Automaton]],
+            resultConstraint : Automaton)
+          : (Iterator[Seq[Automaton]], Seq[Seq[Automaton]]) =
+    resultConstraint match {
+      case resultConstraint : AtomicStateAutomaton =>
+        // TODO: what should the second element be?
+        (Iterator(Seq(resultConstraint)), List())
+
+      case _ =>
+        throw new IllegalArgumentException
+    }
+
+  def eval(arguments : Seq[Seq[Int]]) : Option[Seq[Int]] =
+    Some(arguments(0))
+
+  override def forwardApprox(argumentConstraints : Seq[Seq[Automaton]]) : Automaton = {
+    val cons = argumentConstraints(0).map(_ match {
+        case saut : AtomicStateAutomaton => saut
+        case _ => throw new IllegalArgumentException("NOPPreOp.forwardApprox can only approximate AtomicStateAutomata")
+    })
+    ProductAutomaton(cons)
+  }
+}
+

--- a/src/main/scala/ostrich/preop/ReplaceAllPreOp.scala
+++ b/src/main/scala/ostrich/preop/ReplaceAllPreOp.scala
@@ -60,7 +60,7 @@ abstract class ReplaceAllPreOpBase {
   def apply(s : String) : PreOp = ReplaceAllPreOpWord(s.toSeq)
 }
 
-object ReplaceAllPreOp extends ReplaceAllPreOpBase {
+object ReplaceAllLongestPreOp extends ReplaceAllPreOpBase {
   /**
    * PreOp for x = replaceall(y, e, z) for regex e
    */
@@ -72,7 +72,7 @@ object ReplaceAllPreOp extends ReplaceAllPreOpBase {
    * automaton aut
    */
   def apply(aut : AtomicStateAutomaton) : PreOp =
-    ReplaceAllPreOpRegEx(aut)
+    ReplaceAllLongestPreOpRegEx(aut)
 }
 
 object ReplaceAllShortestPreOp extends ReplaceAllPreOpBase {
@@ -247,7 +247,7 @@ object ReplaceAllPreOpWord {
  * Companion class for building representation of x = replaceall(y, e,
  * z) for a regular expression e.
  */
-object ReplaceAllPreOpRegEx {
+object ReplaceAllLongestPreOpRegEx {
   import Transducer._
 
   /**

--- a/src/main/scala/ostrich/preop/ReplaceAllPreOp.scala
+++ b/src/main/scala/ostrich/preop/ReplaceAllPreOp.scala
@@ -209,12 +209,20 @@ object ReplaceAllPreOpWord {
         if (!handledChars.contains(charNext) && buffer.endsWith(prefix)) {
           val rejectedOldMatchSize = buffer.size - prefix.size
           val rejectedOldMatchPart = buffer.slice(0, rejectedOldMatchSize)
+          // next char either part of next match or last char and not
+          // buffered
           val rejectedOutput = OutputOp(rejectedOldMatchPart, NOP, "")
+          val rejectedOutputFin = OutputOp(rejectedOldMatchPart, Plus(0), "")
 
           builder.addTransition(states(i),
                                 (charNext, charNext),
                                 rejectedOutput,
                                 states(prefix.size + 1))
+          // or word ends here...
+          builder.addTransition(states(i),
+                                (charNext, charNext),
+                                rejectedOutputFin,
+                                finstates(i))
 
           handledChars.add(charNext)
         }

--- a/src/main/scala/ostrich/preop/ReplaceAllPreOp.scala
+++ b/src/main/scala/ostrich/preop/ReplaceAllPreOp.scala
@@ -1,21 +1,21 @@
 /**
  * This file is part of Ostrich, an SMT solver for strings.
  * Copyright (c) 2018-2022 Matthew Hague, Philipp Ruemmer. All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * * Redistributions of source code must retain the above copyright notice, this
  *   list of conditions and the following disclaimer.
- * 
+ *
  * * Redistributions in binary form must reproduce the above copyright notice,
  *   this list of conditions and the following disclaimer in the documentation
  *   and/or other materials provided with the distribution.
- * 
+ *
  * * Neither the name of the authors nor the names of their
  *   contributors may be used to endorse or promote products derived from
  *   this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -46,7 +46,7 @@ import scala.collection.mutable.{HashMap => MHashMap,
                                  Stack => MStack,
                                  HashSet => MHashSet}
 
-object ReplaceAllPreOp {
+abstract class ReplaceAllPreOpBase {
   def apply(a : Char) : PreOp = new ReplaceAllPreOpChar(a)
 
   def apply(w : Seq[Char]) : PreOp = {
@@ -57,8 +57,10 @@ object ReplaceAllPreOp {
     }
   }
 
-  def apply(s : String) : PreOp = ReplaceAllPreOp(s.toSeq)
+  def apply(s : String) : PreOp = ReplaceAllPreOpWord(s.toSeq)
+}
 
+object ReplaceAllPreOp extends ReplaceAllPreOpBase {
   /**
    * PreOp for x = replaceall(y, e, z) for regex e
    */
@@ -71,6 +73,15 @@ object ReplaceAllPreOp {
    */
   def apply(aut : AtomicStateAutomaton) : PreOp =
     ReplaceAllPreOpRegEx(aut)
+}
+
+object ReplaceAllShortestPreOp extends ReplaceAllPreOpBase {
+  /**
+   * PreOp for x = replaceall(y, e, z) for regex e represented as
+   * automaton aut under shortest match semantics
+   */
+  def apply(aut : AtomicStateAutomaton) : PreOp =
+    ReplaceAllShortestPreOpRegEx(aut)
 }
 
 /**
@@ -372,6 +383,126 @@ object ReplaceAllPreOpRegEx {
             if (initImg.exists(aut.isAccept(_))) {
               val oneCharMatch = getState(EndMatch(initImg), frontImg ++ noreachImg)
               builder.addTransition(ts, lbl, internal, oneCharMatch)
+            }
+          }
+        }
+      }
+    }
+
+    val tran = builder.getTransducer
+    tran
+  }
+}
+
+/**
+ * Companion class for building representation of x = replaceall(y, e,
+ * z) for a regular expression e under the shortest match replaced
+ * semantics.
+ */
+object ReplaceAllShortestPreOpRegEx {
+  import Transducer._
+
+  /**
+   * Build preop from aut giving regex to be replaced
+   */
+  def apply(aut : AtomicStateAutomaton) : PreOp = {
+    val tran = buildTransducer(aut)
+    new ReplaceAllPreOpTran(tran)
+  }
+
+  /**
+   * Builds transducer that identifies leftmost and shortest matches of
+   * regex by rewriting matches to internalChar.
+   *
+   * Note: SMT-LIB 2.6 specifies that for replace_all_re, only non-empty
+   * matches are replaced. (Also leftmost, shortest.)
+   */
+  private def buildTransducer(aut : AtomicStateAutomaton) : Transducer = {
+    abstract class Mode
+    // not matching
+    case object NotMatching extends Mode
+    // matching, word read so far could reach any state in frontier
+    case class Matching(val frontier : Set[aut.State]) extends Mode
+
+    val labels = aut.labelEnumerator.enumDisjointLabelsComplete
+    val builder = aut.getTransducerBuilder
+    val nop = OutputOp("", NOP, "")
+    val copy = OutputOp("", Plus(0), "")
+    val internal = OutputOp("", Internal, "")
+
+    // states of transducer have current mode and a set of states that
+    // should never reach a final state (if they do, a match has been
+    // missed)
+    val sMap = new MHashMap[aut.State, (Mode, Set[aut.State])]
+    val sMapRev = new MHashMap[(Mode, Set[aut.State]), aut.State]
+
+    // states of new transducer to be constructed
+    val worklist = new MStack[aut.State]
+
+    def mapState(s : aut.State, q : (Mode, Set[aut.State])) = {
+      sMap += (s -> q)
+      sMapRev += (q -> s)
+    }
+
+    // creates and adds to worklist any new states if needed
+    def getState(m : Mode, noreach : Set[aut.State]) : aut.State = {
+      sMapRev.getOrElse((m, noreach), {
+        val s = builder.getNewState
+        mapState(s, (m, noreach))
+        val goodNoreach = !noreach.exists(aut.isAccept(_))
+        builder.setAccept(s, m match {
+          case NotMatching => goodNoreach
+          case Matching(_) => false
+        })
+        if (goodNoreach)
+          worklist.push(s)
+        s
+      })
+    }
+
+    val autInit = aut.initialState
+    val tranInit = builder.initialState
+
+    mapState(tranInit, (NotMatching, Set.empty[aut.State]))
+    builder.setAccept(tranInit, true)
+    worklist.push(tranInit)
+
+    while (!worklist.isEmpty) {
+      val ts = worklist.pop()
+      val (mode, noreach) = sMap(ts)
+
+      mode match {
+        case NotMatching => {
+          for (lbl <- labels) {
+            val initImg = aut.getImage(autInit, lbl)
+            val noreachImg = aut.getImage(noreach, lbl)
+
+            val dontMatch = getState(NotMatching, noreachImg ++ initImg)
+            builder.addTransition(ts, lbl, copy, dontMatch)
+
+            // either we do a 1-char match (shortest) or we have to keep
+            // the frontier
+            if (initImg.exists(aut.isAccept(_))) {
+              val oneCharMatch = getState(NotMatching, noreachImg)
+              builder.addTransition(ts, lbl, internal, oneCharMatch)
+            } else if (!initImg.isEmpty) {
+              val newMatch = getState(Matching(initImg), noreachImg)
+              builder.addTransition(ts, lbl, nop, newMatch)
+            }
+          }
+        }
+        case Matching(frontier) => {
+          for (lbl <- labels) {
+            val frontImg = aut.getImage(frontier, lbl)
+            val noreachImg = aut.getImage(noreach, lbl)
+
+            // if we found a match, we stop because shortest
+            if (frontImg.exists(aut.isAccept(_))) {
+                val stopMatch = getState(NotMatching, noreachImg)
+                builder.addTransition(ts, lbl, internal, stopMatch)
+            } else if (!frontImg.isEmpty) {
+              val contMatch = getState(Matching(frontImg), noreachImg)
+              builder.addTransition(ts, lbl, nop, contMatch)
             }
           }
         }

--- a/src/main/scala/ostrich/preop/ReplaceAllPreOp.scala
+++ b/src/main/scala/ostrich/preop/ReplaceAllPreOp.scala
@@ -160,8 +160,12 @@ object ReplaceAllPreOpWord {
   import Transducer._
 
   def apply(w : Seq[Char]) = {
-    val wtran = buildWordTransducer(w)
-    new ReplaceAllPreOpTran(wtran)
+    if (w.isEmpty) {
+      NOPPreOp
+    } else {
+      val wtran = buildWordTransducer(w)
+      new ReplaceAllPreOpTran(wtran)
+    }
   }
 
   private def buildWordTransducer(w : Seq[Char]) : Transducer = {
@@ -405,7 +409,7 @@ object ReplaceAllLongestPreOpRegEx {
 /**
  * Companion class for building representation of x = replaceall(y, e,
  * z) for a regular expression e under the shortest match replaced
- * semantics.
+ * semantics. SMT-LIB semantics is only non-empty matches are replaced.
  */
 object ReplaceAllShortestPreOpRegEx {
   import Transducer._
@@ -422,8 +426,8 @@ object ReplaceAllShortestPreOpRegEx {
    * Builds transducer that identifies leftmost and shortest matches of
    * regex by rewriting matches to internalChar.
    *
-   * Note: SMT-LIB 2.6 specifies that for replace_all_re, only non-empty
-   * matches are replaced. (Also leftmost, shortest.)
+   * Assumes that aut does not accept epsilon (in which case SMT-LIB
+   * semantics are that the string should be returned unchanged).
    */
   private def buildTransducer(aut : AtomicStateAutomaton) : Transducer = {
     abstract class Mode
@@ -586,5 +590,4 @@ class ReplaceAllPreOpTran(tran : Transducer) extends PreOp {
     PostImageAutomaton(yProd, tran, Some(zProd))
   }
 }
-
 

--- a/src/main/scala/ostrich/preop/ReplacePreOp.scala
+++ b/src/main/scala/ostrich/preop/ReplacePreOp.scala
@@ -146,12 +146,20 @@ object ReplacePreOpWord {
         if (!handledChars.contains(charNext) && buffer.endsWith(prefix)) {
           val rejectedOldMatchSize = buffer.size - prefix.size
           val rejectedOldMatchPart = buffer.slice(0, rejectedOldMatchSize)
+          // next char either part of next match or last char and not
+          // buffered
           val rejectedOutput = OutputOp(rejectedOldMatchPart, NOP, "")
+          val rejectedOutputFin = OutputOp(rejectedOldMatchPart, Plus(0), "")
 
           builder.addTransition(states(i),
                                 (charNext, charNext),
                                 rejectedOutput,
                                 states(prefix.size + 1))
+          // or word ends here...
+          builder.addTransition(states(i),
+                                (charNext, charNext),
+                                rejectedOutputFin,
+                                finstates(i))
 
           handledChars.add(charNext)
         }
@@ -163,7 +171,7 @@ object ReplacePreOpWord {
       }
 
       // handle word ending in middle of match
-      val outop = if (i == w.size -1) internal else output
+      val outop = if (i == w.size - 1) internal else output
       builder.addTransition(states(i), (w(i), w(i)), outop, finstates(i))
     }
 

--- a/src/main/scala/ostrich/preop/ReplacePreOp.scala
+++ b/src/main/scala/ostrich/preop/ReplacePreOp.scala
@@ -54,7 +54,7 @@ abstract class ReplacePreOpBase {
   def apply(s : String) : PreOp = ReplacePreOpWord(s.toSeq)
 }
 
-object ReplacePreOp extends ReplacePreOpBase {
+object ReplaceLongestPreOp extends ReplacePreOpBase {
   /**
    * PreOp for x = replace(y, e, z) for regex e
    */
@@ -66,7 +66,7 @@ object ReplacePreOp extends ReplacePreOpBase {
    * automaton aut
    */
   def apply(aut : AtomicStateAutomaton) : PreOp =
-    ReplacePreOpRegEx(aut)
+    ReplaceLongestPreOpRegEx(aut)
 }
 
 object ReplaceShortestPreOp extends ReplacePreOpBase {
@@ -184,7 +184,7 @@ object ReplacePreOpWord {
  * Companion class for building representation of x = replace(y, e,
  * z) for a regular expression e.
  */
-object ReplacePreOpRegEx {
+object ReplaceLongestPreOpRegEx {
   import Transducer._
 
   /**
@@ -524,11 +524,11 @@ class ReplacePreOpTran(tran : Transducer) extends PreOp {
   override def forwardApprox(argumentConstraints : Seq[Seq[Automaton]]) : Automaton = {
     val yCons = argumentConstraints(0).map(_ match {
         case saut : AtomicStateAutomaton => saut
-        case _ => throw new IllegalArgumentException("ConcatPreOp.forwardApprox can only approximate AtomicStateAutomata")
+        case _ => throw new IllegalArgumentException("ReplacePreOp.forwardApprox can only approximate AtomicStateAutomata")
     })
     val zCons = argumentConstraints(1).map(_ match {
         case saut : AtomicStateAutomaton => saut
-        case _ => throw new IllegalArgumentException("ConcatPreOp.forwardApprox can only approximate AtomicStateAutomata")
+        case _ => throw new IllegalArgumentException("ReplacePreOp.forwardApprox can only approximate AtomicStateAutomata")
     })
     val yProd = ProductAutomaton(yCons)
     val zProd = ProductAutomaton(zCons)

--- a/src/main/scala/ostrich/preop/ReplacePreOp.scala
+++ b/src/main/scala/ostrich/preop/ReplacePreOp.scala
@@ -86,15 +86,33 @@ object ReplacePreOpWord {
   import Transducer._
 
   def apply(w : Seq[Char]) = {
-    val wtran = buildWordTransducer(w)
+    val wtran = if (w.isEmpty) buildEmptyWordTransducer()
+      else buildNonEmptyWordTransducer(w)
     new ReplacePreOpTran(wtran)
+  }
+
+  private def buildEmptyWordTransducer() : Transducer = {
+    val builder = BricsTransducer.getBuilder
+    val initState = builder.initialState
+    val copyRest = builder.getNewState
+    val internal = OutputOp("", Internal, "")
+    val copy = OutputOp("", Plus(0), "")
+
+    builder.addETransition(initState, internal, copyRest)
+    builder.addTransition(copyRest, builder.LabelOps.sigmaLabel, copy, copyRest)
+    builder.setAccept(copyRest, true)
+
+    val res = builder.getTransducer
+    return res
   }
 
   /**
    * Build transducer that identifies first instance of w and replaces it with
    * internal char
    */
-  private def buildWordTransducer(w : Seq[Char]) : Transducer = {
+  private def buildNonEmptyWordTransducer(w : Seq[Char]) : Transducer = {
+    assert(!w.isEmpty)
+
     val builder = BricsTransducer.getBuilder
 
     val initState = builder.initialState

--- a/src/main/scala/ostrich/preop/ReplacePreOp.scala
+++ b/src/main/scala/ostrich/preop/ReplacePreOp.scala
@@ -42,7 +42,9 @@ import ap.terfor.preds.PredConj
 
 import dk.brics.automaton.RegExp
 
-import scala.collection.mutable.{HashMap => MHashMap, Stack => MStack}
+import scala.collection.mutable.{HashMap => MHashMap,
+                                 Stack => MStack,
+                                 HashSet => MHashSet}
 
 object ReplacePreOp {
   import Transducer._
@@ -91,7 +93,6 @@ object ReplacePreOpWord {
     val finstates = List.fill(w.size)(builder.getNewState)
     val copyRest = builder.getNewState
     val nop = OutputOp("", NOP, "")
-    // TODO: internal
     val internal = OutputOp("", Internal, "")
     val copy = OutputOp("", Plus(0), "")
     val end = w.size - 1
@@ -111,12 +112,46 @@ object ReplacePreOpWord {
     builder.addTransition(copyRest, builder.LabelOps.sigmaLabel, copy, copyRest)
 
     for (i <- 0 until w.size) {
-      val output = OutputOp(w.slice(0, i), Plus(0), "")
+      // the amount of w read up to state i
+      val buffer = w.slice(0, i)
+      // for when we need to output whole prefix read so far
+      val output = OutputOp(buffer, Plus(0), "")
 
-      // begin again if mismatch
+      // if mismatch, look for the largest suffix of the output buffer
+      // that is a correct prefix of the word being searched for. Then
+      // return to the state corresponding to that part of the word.
+
       val anyLbl = builder.LabelOps.sigmaLabel
-      for (lbl <- builder.LabelOps.subtractLetter(w(i), anyLbl))
+
+      // chars that are handled specially (do not return to start)
+      // e.g. the next letter in w
+      val handledChars= new MHashSet[Char]
+      handledChars.add(w(i))
+
+      // for each prefix - we go in reverse so we get the longest ones
+      // first
+      for (j <- i - 1 to 0 by -1) {
+        val prefix = w.slice(0, j)
+        val charNext = w(prefix.size)
+
+        if (!handledChars.contains(charNext) && buffer.endsWith(prefix)) {
+          val rejectedOldMatchSize = buffer.size - prefix.size
+          val rejectedOldMatchPart = buffer.slice(0, rejectedOldMatchSize)
+          val rejectedOutput = OutputOp(rejectedOldMatchPart, NOP, "")
+
+          builder.addTransition(states(i),
+                                (charNext, charNext),
+                                rejectedOutput,
+                                states(prefix.size + 1))
+
+          handledChars.add(charNext)
+        }
+      }
+
+      // letters that should return to start
+      for (lbl <- builder.LabelOps.subtractLetters(handledChars, anyLbl)) {
         builder.addTransition(states(i), lbl, output, states(0))
+      }
 
       // handle word ending in middle of match
       val outop = if (i == w.size -1) internal else output

--- a/src/test/scala/ostrich/preop/NOPPreOpSpecification.scala
+++ b/src/test/scala/ostrich/preop/NOPPreOpSpecification.scala
@@ -1,0 +1,36 @@
+package ostrich.preop
+
+import ostrich.automata.{BricsAutomaton, Automaton, IDState}
+
+import org.scalacheck.Properties
+import org.scalacheck.Prop._
+
+import dk.brics.automaton.{Automaton => BAutomaton, State, Transition}
+
+object NOPPreOpSpecification
+  extends Properties("NOPPreOp"){
+
+  val abcdAut = BricsAutomaton.fromString("abcd")
+
+  def seq(s : String) = s.map(_.toInt)
+
+  property("Simple word nop") = {
+    // abcd = nop(x)
+    NOPPreOp(Seq(Seq()), abcdAut)._1.exists(cons => {
+      cons(0)(seq("abcd"))
+    })
+  }
+
+  property("Simple word nop unchanged") = {
+    // abcd = nop(x)
+    !NOPPreOp(Seq(Seq()), abcdAut)._1.exists(cons => {
+      cons(0)(seq("abcde"))
+    })
+  }
+
+  property("Simple post nop") = {
+    val baut1 = BricsAutomaton.fromString("hello")
+    val post = NOPPreOp.forwardApprox(Seq(Seq(baut1.asInstanceOf[Automaton])))
+    post(seq("hello")) && !post(seq("hello1"))
+  }
+}

--- a/src/test/scala/ostrich/preop/ReplaceAllPreOpSpecification.scala
+++ b/src/test/scala/ostrich/preop/ReplaceAllPreOpSpecification.scala
@@ -295,5 +295,13 @@ object ReplaceAllPreOpSpecification
       Seq(Seq(), Seq(dAut)), ddddAut
     )._1.exists(cons => { cons(0)(seq("dabcabcd")) })
   }
+
+  property("Bug 56 style error") = {
+    // "aa" = replaceAll(x, ab, c) has x = aa
+    val cAut = BricsAutomaton.fromString("c")
+    ReplaceAllShortestPreOp("ab")(
+      Seq(Seq(), Seq(cAut)), aaAut
+    )._1.exists(cons => { cons(0)(seq("aa")) })
+  }
 }
 

--- a/src/test/scala/ostrich/preop/ReplaceAllPreOpSpecification.scala
+++ b/src/test/scala/ostrich/preop/ReplaceAllPreOpSpecification.scala
@@ -25,70 +25,70 @@ object ReplaceAllPreOpSpecification
 
   property("Simple single char test 1") = {
     // abcd = replaceall(x, e, bc)
-    ReplaceAllPreOp('e')(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
+    ReplaceAllLongestPreOp('e')(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
       cons(0)(seq("aed"))
     })
   }
 
   property("Simple single char test 2") = {
     // abcd = replaceall(x, e, bc)
-    ReplaceAllPreOp('e')(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
+    ReplaceAllLongestPreOp('e')(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
       cons(0)(seq("abcd"))
     })
   }
 
   property("Simple single char test 3") = {
     // abcd = replaceall(x, e, bc)
-    !ReplaceAllPreOp('e')(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
+    !ReplaceAllLongestPreOp('e')(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
       cons(0)(seq("abd"))
     })
   }
 
   property("Simple word test 1") = {
     // abcd = replaceall(x, word, bc)
-    ReplaceAllPreOp("word")(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
+    ReplaceAllLongestPreOp("word")(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
       cons(0)(seq("awordd"))
     })
   }
 
   property("Simple word test 2") = {
     // abcd = replaceall(x, word, bc)
-    ReplaceAllPreOp("word")(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
+    ReplaceAllLongestPreOp("word")(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
       cons(0)(seq("abcd"))
     })
   }
 
   property("Simple word test 3") = {
     // abcd = replaceall(x, word, bc)
-    !ReplaceAllPreOp("word")(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
+    !ReplaceAllLongestPreOp("word")(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
       cons(0)(seq("xbcx"))
     })
   }
 
   property("Simple word test 4") = {
     // abcd = replaceall(x, word, bc)
-    !ReplaceAllPreOp("word")(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
+    !ReplaceAllLongestPreOp("word")(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
       cons(0)(seq("word"))
     })
   }
 
   property("Double word test 1") = {
     // aa = replaceall(x, word, a|b)
-    ReplaceAllPreOp("word")(Seq(Seq(), Seq(aorbAut)), aaAut)._1.exists(cons => {
+    ReplaceAllLongestPreOp("word")(Seq(Seq(), Seq(aorbAut)), aaAut)._1.exists(cons => {
       cons(0)(seq("wordword"))
     })
   }
 
   property("Double word test 3") = {
     // aa = replaceall(x, word, a|b)
-    ReplaceAllPreOp("word")(Seq(Seq(), Seq(aorbAut)), aaorbbAut)._1.exists(cons => {
+    ReplaceAllLongestPreOp("word")(Seq(Seq(), Seq(aorbAut)), aaorbbAut)._1.exists(cons => {
       cons(0)(seq("wordword"))
     })
   }
 
   property("Double word test 4") = {
     // aa = replaceall(x, word, a|b)
-    !ReplaceAllPreOp("word")(Seq(Seq(), Seq(aorbAut)), aaorbbAut)._1.exists(cons => {
+    !ReplaceAllLongestPreOp("word")(Seq(Seq(), Seq(aorbAut)), aaorbbAut)._1.exists(cons => {
       cons(0)(seq("ab"))
     })
   }
@@ -96,7 +96,7 @@ object ReplaceAllPreOpSpecification
   property("Regex simple test 1") = {
     // bc = replaceall(x, a*, bc)
     val aut = BricsAutomaton("a*")
-    ReplaceAllPreOp(aut)(Seq(Seq(), Seq(bcAut)), bcAut)._1.exists(cons => {
+    ReplaceAllLongestPreOp(aut)(Seq(Seq(), Seq(bcAut)), bcAut)._1.exists(cons => {
       cons(0)(seq("aaaa"))
     })
   }
@@ -104,7 +104,7 @@ object ReplaceAllPreOpSpecification
   property("Regex simple test 2") = {
     // bc = replaceall(x, a*, bc)
     val aut = BricsAutomaton("a*")
-    ReplaceAllPreOp(aut)(Seq(Seq(), Seq(bcAut)), bcAut)._1.exists(cons => {
+    ReplaceAllLongestPreOp(aut)(Seq(Seq(), Seq(bcAut)), bcAut)._1.exists(cons => {
       cons(0)(seq("bc"))
     })
   }
@@ -112,7 +112,7 @@ object ReplaceAllPreOpSpecification
   property("Regex simple test 3") = {
     // bc = replaceall(x, a*, bc)
     val aut = BricsAutomaton("a*")
-    !ReplaceAllPreOp(aut)(Seq(Seq(), Seq(bcAut)), bcAut)._1.exists(cons => {
+    !ReplaceAllLongestPreOp(aut)(Seq(Seq(), Seq(bcAut)), bcAut)._1.exists(cons => {
       cons(0)(seq("abc"))
     })
   }
@@ -120,7 +120,7 @@ object ReplaceAllPreOpSpecification
   property("Regex leftmost test 1") = {
     // dba = replaceall(x, aba, d)
     val aut = BricsAutomaton("aba")
-    ReplaceAllPreOp(aut)(Seq(Seq(), Seq(dAut)), dbaAut)._1.exists(cons => {
+    ReplaceAllLongestPreOp(aut)(Seq(Seq(), Seq(dAut)), dbaAut)._1.exists(cons => {
       cons(0)(seq("ababa"))
     })
   }
@@ -128,7 +128,7 @@ object ReplaceAllPreOpSpecification
   property("Regex leftmost test 2") = {
     // abd = replaceall(x, aba, d)
     val aut = BricsAutomaton("aba")
-    !ReplaceAllPreOp(aut)(Seq(Seq(), Seq(dAut)), abdAut)._1.exists(cons => {
+    !ReplaceAllLongestPreOp(aut)(Seq(Seq(), Seq(dAut)), abdAut)._1.exists(cons => {
       cons(0)(seq("ababa"))
     })
   }
@@ -137,7 +137,7 @@ object ReplaceAllPreOpSpecification
     val baut1 = BricsAutomaton.fromString("hello")
     val baut2 = BricsAutomaton.fromString("world")
 
-    val post = ReplaceAllPreOp('l').
+    val post = ReplaceAllLongestPreOp('l').
       forwardApprox(Seq(Seq(baut1.asInstanceOf[Automaton]),
                         Seq(baut2.asInstanceOf[Automaton])))
 
@@ -152,7 +152,7 @@ object ReplaceAllPreOpSpecification
     val baut1 = BricsAutomaton.fromString("hello")
     val baut2 = BricsAutomaton.fromString("world")
 
-    val post = ReplaceAllPreOp("el").
+    val post = ReplaceAllLongestPreOp("el").
       forwardApprox(Seq(Seq(baut1.asInstanceOf[Automaton]),
                         Seq(baut2.asInstanceOf[Automaton])))
 
@@ -168,7 +168,7 @@ object ReplaceAllPreOpSpecification
     val baut2 = BricsAutomaton.fromString("world")
     val regex = BricsAutomaton.fromString("el")
 
-    val post = ReplaceAllPreOp(regex).
+    val post = ReplaceAllLongestPreOp(regex).
       forwardApprox(Seq(Seq(baut1.asInstanceOf[Automaton]),
                         Seq(baut2.asInstanceOf[Automaton])))
 
@@ -190,7 +190,7 @@ object ReplaceAllPreOpSpecification
     aut.setInitialState(q0)
     val regex = new BricsAutomaton(aut)
 
-    val post = ReplaceAllPreOp(regex).
+    val post = ReplaceAllLongestPreOp(regex).
       forwardApprox(Seq(Seq(baut1.asInstanceOf[Automaton]),
                         Seq(baut2.asInstanceOf[Automaton])))
 
@@ -205,7 +205,7 @@ object ReplaceAllPreOpSpecification
     val scscriptriptAut = BricsAutomaton.fromString("scscriptript")
     val tAut = BricsAutomaton.fromString("")
 
-    !ReplaceAllPreOp("scr")(Seq(Seq(), Seq(eAut)),
+    !ReplaceAllLongestPreOp("scr")(Seq(Seq(), Seq(eAut)),
                            scscriptriptAut)._1.exists(cons => {
       cons(0)(seq("scscriptript"))
     })
@@ -215,7 +215,7 @@ object ReplaceAllPreOpSpecification
     val aabaabAut = BricsAutomaton.fromString("aabaab")
     val tAut = BricsAutomaton.fromString("")
 
-    !ReplaceAllPreOp("aabaab")(Seq(Seq(), Seq(eAut)),
+    !ReplaceAllLongestPreOp("aabaab")(Seq(Seq(), Seq(eAut)),
                                aabaabAut)._1.exists(cons => {
       cons(0)(seq("aabaab"))
     })
@@ -225,7 +225,7 @@ object ReplaceAllPreOpSpecification
     val aabaabAut = BricsAutomaton.fromString("ccc")
     val tAut = BricsAutomaton.fromString("")
 
-    ReplaceAllPreOp("aabaab")(Seq(Seq(), Seq(eAut)),
+    ReplaceAllLongestPreOp("aabaab")(Seq(Seq(), Seq(eAut)),
                                aabaabAut)._1.exists(cons => {
       cons(0)(seq("ccc"))
     })
@@ -234,7 +234,7 @@ object ReplaceAllPreOpSpecification
   property("Regex longest catches all") = {
     // dd = replaceAll(x, a*, d) cannot contain aa
     val aut = BricsAutomaton("a*")
-    !ReplaceAllPreOp(aut)(Seq(Seq(), Seq(dAut)), ddAut)._1.exists(cons => {
+    !ReplaceAllLongestPreOp(aut)(Seq(Seq(), Seq(dAut)), ddAut)._1.exists(cons => {
       cons(0)(seq("aa"))
     })
   }

--- a/src/test/scala/ostrich/preop/ReplaceAllPreOpSpecification.scala
+++ b/src/test/scala/ostrich/preop/ReplaceAllPreOpSpecification.scala
@@ -273,7 +273,7 @@ object ReplaceAllPreOpSpecification
 
   property("Regex shortest repeated word match") = {
     // "dd" = replaceAllShortest(x, (abc)+, d) has x = abcabc
-    val aut = BricsAutomaton("abc(abc)*")
+    val aut = BricsAutomaton("(abc)*")
     ReplaceAllShortestPreOp(aut)(
       Seq(Seq(), Seq(dAut)), ddAut
     )._1.exists(cons => { cons(0)(seq("abcabc")) })
@@ -281,7 +281,7 @@ object ReplaceAllPreOpSpecification
 
   property("Regex shortest repeated word match neg") = {
     // "d" = replaceShortest(x, (abc)+, d) has not x = abcabc
-    val aut = BricsAutomaton("abc(abc)*")
+    val aut = BricsAutomaton("(abc)*")
     !ReplaceAllShortestPreOp(aut)(
       Seq(Seq(), Seq(dAut)), dAut
     )._1.exists(cons => { cons(0)(seq("abcabc")) })
@@ -290,7 +290,7 @@ object ReplaceAllPreOpSpecification
   property("Regex middle repeated word match") = {
     // "dddd" = replaceShortest(x, (abc)+, d) has x = dabcabcd
     val ddddAut = BricsAutomaton.fromString("dddd")
-    val aut = BricsAutomaton("abc(abc)*")
+    val aut = BricsAutomaton("(abc)*")
     ReplaceAllShortestPreOp(aut)(
       Seq(Seq(), Seq(dAut)), ddddAut
     )._1.exists(cons => { cons(0)(seq("dabcabcd")) })

--- a/src/test/scala/ostrich/preop/ReplaceAllPreOpSpecification.scala
+++ b/src/test/scala/ostrich/preop/ReplaceAllPreOpSpecification.scala
@@ -303,5 +303,21 @@ object ReplaceAllPreOpSpecification
       Seq(Seq(), Seq(cAut)), aaAut
     )._1.exists(cons => { cons(0)(seq("aa")) })
   }
+
+  property("Unchanged shortest empty") = {
+    // "aa" = replaceAll(x, "", c) has x = aa
+    val cAut = BricsAutomaton.fromString("c")
+    ReplaceAllShortestPreOp("")(
+      Seq(Seq(), Seq(cAut)), aaAut
+    )._1.exists(cons => { cons(0)(seq("aa")) })
+  }
+
+  property("Unchanged shortest empty neg") = {
+    // "c" = replaceAll(x, "", c) has not x = aa
+    val cAut = BricsAutomaton.fromString("c")
+    !ReplaceAllShortestPreOp("")(
+      Seq(Seq(), Seq(cAut)), cAut
+    )._1.exists(cons => { cons(0)(seq("aa")) })
+  }
 }
 

--- a/src/test/scala/ostrich/preop/ReplacePreOpSpecification.scala
+++ b/src/test/scala/ostrich/preop/ReplacePreOpSpecification.scala
@@ -16,6 +16,8 @@ object ReplacePreOpSpecification
   val aorbAut = BricsAutomaton.fromString("a") | BricsAutomaton.fromString("b")
   val aaorbbAut = BricsAutomaton.fromString("aa") | BricsAutomaton.fromString("bb")
   val abdAut = BricsAutomaton.fromString("abd")
+  val cAut = BricsAutomaton.fromString("c")
+  val caaAut = BricsAutomaton.fromString("caa")
   val dbaAut = BricsAutomaton.fromString("dba")
   val dAut = BricsAutomaton.fromString("d")
   val ddAut = BricsAutomaton.fromString("dd")
@@ -328,6 +330,21 @@ object ReplacePreOpSpecification
     // "aa" = replaceShortest(x, ab, c) has x = aa
     val cAut = BricsAutomaton.fromString("c")
     ReplaceShortestPreOp("ab")(
+      Seq(Seq(), Seq(cAut)), aaAut
+    )._1.exists(cons => { cons(0)(seq("aa")) })
+  }
+
+  property("Replace empty string prepend") = {
+    // "caa" = replaceShortest(x, "", c) has x = aa
+    ReplaceShortestPreOp("")(
+      Seq(Seq(), Seq(cAut)), caaAut
+    )._1.exists(cons => { cons(0)(seq("aa")) })
+  }
+
+  property("Replace empty string prepend neg") = {
+    // "aa" = replaceShortest(x, "", c) has not x = aa
+    val cAut = BricsAutomaton.fromString("c")
+    !ReplaceShortestPreOp("")(
       Seq(Seq(), Seq(cAut)), aaAut
     )._1.exists(cons => { cons(0)(seq("aa")) })
   }

--- a/src/test/scala/ostrich/preop/ReplacePreOpSpecification.scala
+++ b/src/test/scala/ostrich/preop/ReplacePreOpSpecification.scala
@@ -1,0 +1,242 @@
+package ostrich.preop
+
+import ostrich.automata.{BricsAutomaton, Automaton, IDState}
+
+import org.scalacheck.Properties
+import org.scalacheck.Prop._
+
+import dk.brics.automaton.{Automaton => BAutomaton, State, Transition}
+
+object ReplacePreOpSpecification
+    extends Properties("ReplacePreOp"){
+
+  val abcdAut = BricsAutomaton.fromString("abcd")
+  val bcAut = BricsAutomaton.fromString("bc")
+  val aaAut = BricsAutomaton.fromString("aa")
+  val aorbAut = BricsAutomaton.fromString("a") | BricsAutomaton.fromString("b")
+  val aaorbbAut = BricsAutomaton.fromString("aa") | BricsAutomaton.fromString("bb")
+  val abdAut = BricsAutomaton.fromString("abd")
+  val dbaAut = BricsAutomaton.fromString("dba")
+  val dAut = BricsAutomaton.fromString("d")
+  val eAut = BricsAutomaton.fromString("")
+
+  def seq(s : String) = s.map(_.toInt)
+
+  property("Simple single char test 1") = {
+    // abcd = replace(x, e, bc)
+    ReplacePreOp('e')(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
+      cons(0)(seq("aed"))
+    })
+  }
+
+  property("Simple single char test 2") = {
+    // abcd = replace(x, e, bc)
+    ReplacePreOp('e')(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
+      cons(0)(seq("abcd"))
+    })
+  }
+
+  property("Simple single char test 3") = {
+    // abcd = replace(x, e, bc)
+    !ReplacePreOp('e')(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
+      cons(0)(seq("abd"))
+    })
+  }
+
+  property("Simple word test 1") = {
+    // abcd = replace(x, word, bc)
+    ReplacePreOp("word")(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
+      cons(0)(seq("awordd"))
+    })
+  }
+
+  property("Simple word test 2") = {
+    // abcd = replace(x, word, bc)
+    ReplacePreOp("word")(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
+      cons(0)(seq("abcd"))
+    })
+  }
+
+  property("Simple word test 3") = {
+    // abcd = replace(x, word, bc)
+    !ReplacePreOp("word")(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
+      cons(0)(seq("xbcx"))
+    })
+  }
+
+  property("Simple word test 4") = {
+    // abcd = replace(x, word, bc)
+    !ReplacePreOp("word")(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
+      cons(0)(seq("word"))
+    })
+  }
+
+  property("Double word test 1") = {
+    // aa = replace(x, word, a|b)
+    ReplacePreOp("word")(Seq(Seq(), Seq(aorbAut)), aaAut)._1.exists(cons => {
+      cons(0)(seq("worda"))
+    })
+  }
+
+  property("Double word test 2") = {
+    // aa = replace(x, word, a|b)
+    !ReplacePreOp("word")(Seq(Seq(), Seq(aorbAut)), aaAut)._1.exists(cons => {
+      cons(0)(seq("wordword"))
+    })
+  }
+
+  property("Double word test 3") = {
+    // (aa|bb) = replace(x, word, a|b)
+    !ReplacePreOp("word")(Seq(Seq(), Seq(aorbAut)), aaorbbAut)._1.exists(cons => {
+      cons(0)(seq("ab"))
+    })
+  }
+
+  property("Regex simple test 1") = {
+    // bc = replace(x, a*, bc)
+    val aut = BricsAutomaton("a*")
+    ReplacePreOp(aut)(Seq(Seq(), Seq(bcAut)), bcAut)._1.exists(cons => {
+      cons(0)(seq("aaaa"))
+    })
+  }
+
+  property("Regex simple test 2") = {
+    // bc = replace(x, a*, bc)
+    val aut = BricsAutomaton("a*")
+    ReplacePreOp(aut)(Seq(Seq(), Seq(bcAut)), bcAut)._1.exists(cons => {
+      cons(0)(seq("bc"))
+    })
+  }
+
+  property("Regex simple test 3") = {
+    // bc = replace(x, a*, bc)
+    val aut = BricsAutomaton("a*")
+    !ReplacePreOp(aut)(Seq(Seq(), Seq(bcAut)), bcAut)._1.exists(cons => {
+      cons(0)(seq("abc"))
+    })
+  }
+
+  property("Regex leftmost test 1") = {
+    // dba = replace(x, aba, d)
+    val aut = BricsAutomaton("aba")
+    ReplacePreOp(aut)(Seq(Seq(), Seq(dAut)), dbaAut)._1.exists(cons => {
+      cons(0)(seq("ababa"))
+    })
+  }
+
+  property("Regex leftmost test 2") = {
+    // abd = replace(x, aba, d)
+    val aut = BricsAutomaton("aba")
+    !ReplacePreOp(aut)(Seq(Seq(), Seq(dAut)), abdAut)._1.exists(cons => {
+      cons(0)(seq("ababa"))
+    })
+  }
+
+  property("Simple Post Char") = {
+    val baut1 = BricsAutomaton.fromString("hello")
+    val baut2 = BricsAutomaton.fromString("world")
+
+    val post = ReplacePreOp('l').
+      forwardApprox(Seq(Seq(baut1.asInstanceOf[Automaton]),
+                        Seq(baut2.asInstanceOf[Automaton])))
+
+    // negative ones are subjective i suppose due to over-approx
+    post(seq("heworldlo")) &&
+      !post(seq("hello")) &&
+      !post(seq("hworldwordo")) &&
+      !post(seq("hworldllo"))
+  }
+
+  property("Simple Post Word") = {
+    val baut1 = BricsAutomaton.fromString("hello")
+    val baut2 = BricsAutomaton.fromString("world")
+
+    val post = ReplacePreOp("el").
+      forwardApprox(Seq(Seq(baut1.asInstanceOf[Automaton]),
+                        Seq(baut2.asInstanceOf[Automaton])))
+
+    // negative ones are subjective i suppose due to over-approx
+    post(seq("hworldlo")) &&
+      !post(seq("hello")) &&
+      !post(seq("hworldo")) &&
+      !post(seq("hworldllo"))
+  }
+
+  property("Simple Post Regex") = {
+    val baut1 = BricsAutomaton.fromString("hello")
+    val baut2 = BricsAutomaton.fromString("world")
+    val regex = BricsAutomaton.fromString("el")
+
+    val post = ReplacePreOp(regex).
+      forwardApprox(Seq(Seq(baut1.asInstanceOf[Automaton]),
+                        Seq(baut2.asInstanceOf[Automaton])))
+
+    // negative ones are subjective i suppose due to over-approx
+    post(seq("hworldlo")) &&
+      !post(seq("hello")) &&
+      !post(seq("hworldo")) &&
+      !post(seq("hworldllo"))
+  }
+
+  property("Simple Post Regex Loop") = {
+    val baut1 = BricsAutomaton.fromString("hello")
+    val baut2 = BricsAutomaton.fromString("world")
+
+    val q0 = new IDState(0)
+    q0.addTransition(new Transition('l', q0))
+    q0.setAccept(true)
+    val aut = new BAutomaton
+    aut.setInitialState(q0)
+    val regex = new BricsAutomaton(aut)
+
+    val post = ReplacePreOp(regex).
+      forwardApprox(Seq(Seq(baut1.asInstanceOf[Automaton]),
+                        Seq(baut2.asInstanceOf[Automaton])))
+
+    // negative ones are subjective i suppose due to over-approx
+    post(seq("heworldo")) &&
+      !post(seq("heworldlo")) &&
+      !post(seq("hworldo")) &&
+      !post(seq("hworldllo"))
+  }
+
+  property("Bug from Philipp 20 May 2020") = {
+    val scscriptriptAut = BricsAutomaton.fromString("scscriptript")
+    val tAut = BricsAutomaton.fromString("")
+
+    !ReplacePreOp("scr")(Seq(Seq(), Seq(eAut)),
+                           scscriptriptAut)._1.exists(cons => {
+      cons(0)(seq("scscriptript"))
+    })
+  }
+
+  property("Transducer over cycling word") = {
+    val aabaabAut = BricsAutomaton.fromString("aabaab")
+    val tAut = BricsAutomaton.fromString("")
+
+    !ReplacePreOp("aabaab")(Seq(Seq(), Seq(eAut)),
+                               aabaabAut)._1.exists(cons => {
+      cons(0)(seq("aabaab"))
+    })
+  }
+
+  property("Pre-image over a non replaced word contains original word") = {
+    val aabaabAut = BricsAutomaton.fromString("ccc")
+    val tAut = BricsAutomaton.fromString("")
+
+    ReplacePreOp("aabaab")(Seq(Seq(), Seq(eAut)),
+                               aabaabAut)._1.exists(cons => {
+      cons(0)(seq("ccc"))
+    })
+  }
+
+  property("Regex longest catches all") = {
+    // dd = replace(x, a*, d) cannot contain aa
+    val ddAut = BricsAutomaton.fromString("dd")
+    val aut = BricsAutomaton("a*")
+    !ReplacePreOp(aut)(Seq(Seq(), Seq(dAut)), ddAut)._1.exists(cons => {
+      cons(0)(seq("aa"))
+    })
+  }
+}
+

--- a/src/test/scala/ostrich/preop/ReplacePreOpSpecification.scala
+++ b/src/test/scala/ostrich/preop/ReplacePreOpSpecification.scala
@@ -323,5 +323,13 @@ object ReplacePreOpSpecification
       Seq(Seq(), Seq(dAut)), ddabcdAut
     )._1.exists(cons => { cons(0)(seq("dabcabcd")) })
   }
+
+  property("Bug 56 error") = {
+    // "aa" = replaceShortest(x, ab, c) has x = aa
+    val cAut = BricsAutomaton.fromString("c")
+    ReplaceShortestPreOp("ab")(
+      Seq(Seq(), Seq(cAut)), aaAut
+    )._1.exists(cons => { cons(0)(seq("aa")) })
+  }
 }
 

--- a/src/test/scala/ostrich/preop/ReplacePreOpSpecification.scala
+++ b/src/test/scala/ostrich/preop/ReplacePreOpSpecification.scala
@@ -25,70 +25,70 @@ object ReplacePreOpSpecification
 
   property("Simple single char test 1") = {
     // abcd = replace(x, e, bc)
-    ReplacePreOp('e')(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
+    ReplaceLongestPreOp('e')(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
       cons(0)(seq("aed"))
     })
   }
 
   property("Simple single char test 2") = {
     // abcd = replace(x, e, bc)
-    ReplacePreOp('e')(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
+    ReplaceLongestPreOp('e')(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
       cons(0)(seq("abcd"))
     })
   }
 
   property("Simple single char test 3") = {
     // abcd = replace(x, e, bc)
-    !ReplacePreOp('e')(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
+    !ReplaceLongestPreOp('e')(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
       cons(0)(seq("abd"))
     })
   }
 
   property("Simple word test 1") = {
     // abcd = replace(x, word, bc)
-    ReplacePreOp("word")(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
+    ReplaceLongestPreOp("word")(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
       cons(0)(seq("awordd"))
     })
   }
 
   property("Simple word test 2") = {
     // abcd = replace(x, word, bc)
-    ReplacePreOp("word")(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
+    ReplaceLongestPreOp("word")(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
       cons(0)(seq("abcd"))
     })
   }
 
   property("Simple word test 3") = {
     // abcd = replace(x, word, bc)
-    !ReplacePreOp("word")(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
+    !ReplaceLongestPreOp("word")(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
       cons(0)(seq("xbcx"))
     })
   }
 
   property("Simple word test 4") = {
     // abcd = replace(x, word, bc)
-    !ReplacePreOp("word")(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
+    !ReplaceLongestPreOp("word")(Seq(Seq(), Seq(bcAut)), abcdAut)._1.exists(cons => {
       cons(0)(seq("word"))
     })
   }
 
   property("Double word test 1") = {
     // aa = replace(x, word, a|b)
-    ReplacePreOp("word")(Seq(Seq(), Seq(aorbAut)), aaAut)._1.exists(cons => {
+    ReplaceLongestPreOp("word")(Seq(Seq(), Seq(aorbAut)), aaAut)._1.exists(cons => {
       cons(0)(seq("worda"))
     })
   }
 
   property("Double word test 2") = {
     // aa = replace(x, word, a|b)
-    !ReplacePreOp("word")(Seq(Seq(), Seq(aorbAut)), aaAut)._1.exists(cons => {
+    !ReplaceLongestPreOp("word")(Seq(Seq(), Seq(aorbAut)), aaAut)._1.exists(cons => {
       cons(0)(seq("wordword"))
     })
   }
 
   property("Double word test 3") = {
     // (aa|bb) = replace(x, word, a|b)
-    !ReplacePreOp("word")(Seq(Seq(), Seq(aorbAut)), aaorbbAut)._1.exists(cons => {
+    !ReplaceLongestPreOp("word")(Seq(Seq(), Seq(aorbAut)), aaorbbAut)._1.exists(cons => {
       cons(0)(seq("ab"))
     })
   }
@@ -96,7 +96,7 @@ object ReplacePreOpSpecification
   property("Regex simple test 1") = {
     // bc = replace(x, a*, bc)
     val aut = BricsAutomaton("a*")
-    ReplacePreOp(aut)(Seq(Seq(), Seq(bcAut)), bcAut)._1.exists(cons => {
+    ReplaceLongestPreOp(aut)(Seq(Seq(), Seq(bcAut)), bcAut)._1.exists(cons => {
       cons(0)(seq("aaaa"))
     })
   }
@@ -104,7 +104,7 @@ object ReplacePreOpSpecification
   property("Regex simple test 2") = {
     // bc = replace(x, a*, bc)
     val aut = BricsAutomaton("a*")
-    ReplacePreOp(aut)(Seq(Seq(), Seq(bcAut)), bcAut)._1.exists(cons => {
+    ReplaceLongestPreOp(aut)(Seq(Seq(), Seq(bcAut)), bcAut)._1.exists(cons => {
       cons(0)(seq("bc"))
     })
   }
@@ -112,7 +112,7 @@ object ReplacePreOpSpecification
   property("Regex simple test 3") = {
     // bc = replace(x, a*, bc)
     val aut = BricsAutomaton("a*")
-    !ReplacePreOp(aut)(Seq(Seq(), Seq(bcAut)), bcAut)._1.exists(cons => {
+    !ReplaceLongestPreOp(aut)(Seq(Seq(), Seq(bcAut)), bcAut)._1.exists(cons => {
       cons(0)(seq("abc"))
     })
   }
@@ -120,7 +120,7 @@ object ReplacePreOpSpecification
   property("Regex leftmost test 1") = {
     // dba = replace(x, aba, d)
     val aut = BricsAutomaton("aba")
-    ReplacePreOp(aut)(Seq(Seq(), Seq(dAut)), dbaAut)._1.exists(cons => {
+    ReplaceLongestPreOp(aut)(Seq(Seq(), Seq(dAut)), dbaAut)._1.exists(cons => {
       cons(0)(seq("ababa"))
     })
   }
@@ -128,7 +128,7 @@ object ReplacePreOpSpecification
   property("Regex leftmost test 2") = {
     // abd = replace(x, aba, d)
     val aut = BricsAutomaton("aba")
-    !ReplacePreOp(aut)(Seq(Seq(), Seq(dAut)), abdAut)._1.exists(cons => {
+    !ReplaceLongestPreOp(aut)(Seq(Seq(), Seq(dAut)), abdAut)._1.exists(cons => {
       cons(0)(seq("ababa"))
     })
   }
@@ -137,7 +137,7 @@ object ReplacePreOpSpecification
     val baut1 = BricsAutomaton.fromString("hello")
     val baut2 = BricsAutomaton.fromString("world")
 
-    val post = ReplacePreOp('l').
+    val post = ReplaceLongestPreOp('l').
       forwardApprox(Seq(Seq(baut1.asInstanceOf[Automaton]),
                         Seq(baut2.asInstanceOf[Automaton])))
 
@@ -152,7 +152,7 @@ object ReplacePreOpSpecification
     val baut1 = BricsAutomaton.fromString("hello")
     val baut2 = BricsAutomaton.fromString("world")
 
-    val post = ReplacePreOp("el").
+    val post = ReplaceLongestPreOp("el").
       forwardApprox(Seq(Seq(baut1.asInstanceOf[Automaton]),
                         Seq(baut2.asInstanceOf[Automaton])))
 
@@ -168,7 +168,7 @@ object ReplacePreOpSpecification
     val baut2 = BricsAutomaton.fromString("world")
     val regex = BricsAutomaton.fromString("el")
 
-    val post = ReplacePreOp(regex).
+    val post = ReplaceLongestPreOp(regex).
       forwardApprox(Seq(Seq(baut1.asInstanceOf[Automaton]),
                         Seq(baut2.asInstanceOf[Automaton])))
 
@@ -190,7 +190,7 @@ object ReplacePreOpSpecification
     aut.setInitialState(q0)
     val regex = new BricsAutomaton(aut)
 
-    val post = ReplacePreOp(regex).
+    val post = ReplaceLongestPreOp(regex).
       forwardApprox(Seq(Seq(baut1.asInstanceOf[Automaton]),
                         Seq(baut2.asInstanceOf[Automaton])))
 
@@ -205,7 +205,7 @@ object ReplacePreOpSpecification
     val scscriptriptAut = BricsAutomaton.fromString("scscriptript")
     val tAut = BricsAutomaton.fromString("")
 
-    !ReplacePreOp("scr")(Seq(Seq(), Seq(eAut)),
+    !ReplaceLongestPreOp("scr")(Seq(Seq(), Seq(eAut)),
                            scscriptriptAut)._1.exists(cons => {
       cons(0)(seq("scscriptript"))
     })
@@ -215,7 +215,7 @@ object ReplacePreOpSpecification
     val aabaabAut = BricsAutomaton.fromString("aabaab")
     val tAut = BricsAutomaton.fromString("")
 
-    !ReplacePreOp("aabaab")(Seq(Seq(), Seq(eAut)),
+    !ReplaceLongestPreOp("aabaab")(Seq(Seq(), Seq(eAut)),
                                aabaabAut)._1.exists(cons => {
       cons(0)(seq("aabaab"))
     })
@@ -225,7 +225,7 @@ object ReplacePreOpSpecification
     val aabaabAut = BricsAutomaton.fromString("ccc")
     val tAut = BricsAutomaton.fromString("")
 
-    ReplacePreOp("aabaab")(Seq(Seq(), Seq(eAut)),
+    ReplaceLongestPreOp("aabaab")(Seq(Seq(), Seq(eAut)),
                                aabaabAut)._1.exists(cons => {
       cons(0)(seq("ccc"))
     })
@@ -234,7 +234,7 @@ object ReplacePreOpSpecification
   property("Regex longest catches all") = {
     // dd = replace(x, a*, d) cannot contain aa
     val aut = BricsAutomaton("a*")
-    !ReplacePreOp(aut)(Seq(Seq(), Seq(dAut)), ddAut)._1.exists(cons => {
+    !ReplaceLongestPreOp(aut)(Seq(Seq(), Seq(dAut)), ddAut)._1.exists(cons => {
       cons(0)(seq("aa"))
     })
   }


### PR DESCRIPTION
* Add a bunch of tests for ReplacePreOp that should have been there long ago
* Fix old bugs with string replacement (I still wasn't building the right transducer from the string..)
    * Original fix 69c2ae897f5dd36b1815a5976a1e6b48053d3e78 wasn't quite right, and should have been done for ReplacePreOp too.
* Add ReplaceAllShortestPreOp, rename existing pre-op to ReplaceAllLongestPreOp
    * For regex, longest and shortest both only look for non-empty matches, which is ok by SMT-LIB
* Add ReplaceShortestPreOp, rename existing pre-op to ReplaceLongestPreOp
    * Implement correct prepend semantics for shortest if regex accepts the empty word
* When replace_all s t t' when t is empty, then return s unchanged (via a new NOPPreOp)
* When replace s t t' when t is empty, return t's as per SMT-LIB