### PR TITLE
add limited support for str.<= (constant on one side is supported)

### DIFF
--- a/src/main/scala/ostrich/OstrichReducer.scala
+++ b/src/main/scala/ostrich/OstrichReducer.scala
@@ -107,7 +107,7 @@ class OstrichReducer protected[ostrich]
 
   import OstrichReducer._
 
-  import theory.{_str_empty, _str_cons, _str_++, _str_char_count,
+  import theory.{_str_empty, _str_cons, _str_++, str_<=, _str_char_count,
                  str_empty, str_cons, str_in_re_id, str_prefixof,
                  str_suffixof, str_contains,
                  str_replace, str_replaceall,
@@ -162,7 +162,7 @@ class OstrichReducer protected[ostrich]
 
     ReducerPlugin.rewritePreds(predConj,
                                (List(_str_empty, _str_cons,
-                                     str_in_re_id, _str_len, _str_char_count,
+                                     str_in_re_id, _str_len, _str_char_count, str_<=,
                                      _int_to_str, _str_to_int,
                                      str_prefixof, str_suffixof, str_contains,
                                      FunPred(str_replace),
@@ -368,6 +368,18 @@ class OstrichReducer protected[ostrich]
 
         case FunPred(`str_replaceall`) if hasValue(a(1), List()) =>
           a(0) === a(3)
+
+        case `str_<=` if (isConcrete(a(1))) => {
+
+          val autId = autDatabase.automaton2Id(BricsAutomaton.smallerEqAutomaton(term2Str(a(1)).get))
+          str_in_re_id(List(a(0), l(autId)))
+        }
+
+        case `str_<=` if (isConcrete(a(0))) => {
+
+          val autId = autDatabase.automaton2Id(BricsAutomaton.greaterEqAutomaton(term2Str(a(0)).get))
+          str_in_re_id(List(a(1), l(autId)))
+        }
 
         case p => {
           try {

--- a/src/main/scala/ostrich/OstrichReducer.scala
+++ b/src/main/scala/ostrich/OstrichReducer.scala
@@ -370,7 +370,6 @@ class OstrichReducer protected[ostrich]
           a(0) === a(3)
 
         case `str_<=` if (isConcrete(a(1))) => {
-
           val autId = autDatabase.automaton2Id(BricsAutomaton.smallerEqAutomaton(term2Str(a(1)).get))
           str_in_re_id(List(a(0), l(autId)))
         }

--- a/src/main/scala/ostrich/OstrichStringTheory.scala
+++ b/src/main/scala/ostrich/OstrichStringTheory.scala
@@ -290,7 +290,7 @@ class OstrichStringTheory(transducers : Seq[(String, Transducer)],
 
   // Set of the predicates that are fully supported at this point
   private val supportedPreds : Set[Predicate] =
-    Set(str_in_re, str_in_re_id, str_prefixof, str_suffixof) ++
+    Set(str_in_re, str_in_re_id, str_prefixof, str_suffixof, str_<=) ++
     (for (f <- Set(str_empty, str_cons, str_at,
                    str_++, str_replace, str_replaceall,
                    str_replacere, str_replaceallre,

--- a/src/main/scala/ostrich/automata/BricsAutomaton.scala
+++ b/src/main/scala/ostrich/automata/BricsAutomaton.scala
@@ -154,6 +154,104 @@ object BricsAutomaton {
       new BricsAutomaton(BAutomaton.makeAnyString)
 
   /**
+   * A new automaton that accepts all strings x <= str (lexicographical ordering)
+   */
+
+  def smallerEqAutomaton(str : String) : BricsAutomaton = {
+    /*
+    Initial state is accepting.
+    Have one accepting sink state where every letter can be read because we are already smaller.
+    Have additional state per char 'c' in the string to check for equality.
+      Each of those additional states have one transition to the sink state reading ['c'+1, 65535]
+      Each of those additional states have one transition to the next state reading ['c', 'c']
+    The last state has no outgoing transitions.
+     */
+    val builder = new BricsAutomatonBuilder
+    val initital_state = builder.getNewState
+
+    builder.setInitialState(initital_state)
+    builder.setAccept(initital_state, isAccepting = true)
+    if (str.isEmpty){
+      return builder.getAutomaton
+    }
+
+    val sink_state = builder.getNewState
+    builder.setAccept(sink_state, isAccepting = true)
+
+
+    val first_letter = str.head
+
+    builder.addTransition(initital_state, builder.LabelOps.interval(Char.MinValue, (first_letter-1).toChar), sink_state)
+    builder.addTransition(sink_state, builder.LabelOps.sigmaLabel, sink_state)
+
+    val states =
+      (for (n <- 0 to str.length) yield builder.getNewState).toIndexedSeq
+
+    // add transition to rest of the automaton
+    builder.addTransition(initital_state, builder.LabelOps.singleton(first_letter), states(0))
+    val remaining_str = str.tail
+
+    for ((c,n) <- remaining_str.iterator.zipWithIndex) {
+      // we read x = c -> keep parsing
+      builder.addTransition(states(n),builder.LabelOps.singleton(c), states(n+1))
+      // we read x <= c -> go to sink state
+      builder.addTransition(states(n),builder.LabelOps.interval(Char.MinValue, (c-1).toChar), sink_state)
+      builder.setAccept(states(n), isAccepting = true)
+    }
+
+    builder.getAutomaton
+  }
+  /**
+   * A new automaton that accepts all strings str <= x (lexicographical ordering)
+   */
+  def greaterEqAutomaton(str : String) : BricsAutomaton = {
+    /*
+    Initial state is NOT accepting.
+    Have one accepting sink state where every letter can be read because we are already smaller.
+    Have additional state per char 'c' in the string to check for equality.
+      Each of those additional states have one transition to the sink state reading ['c'+1, 65535]
+      Each of those additional states have one transition to the next state reading ['c', 'c']
+    The last state has no outgoing transitions.
+     */
+    val builder = new BricsAutomatonBuilder
+    val initital_state = builder.getNewState
+
+    builder.setInitialState(initital_state)
+
+    if (str.isEmpty){
+      builder.setAccept(initital_state, isAccepting = true)
+      builder.addTransition(initital_state, builder.LabelOps.sigmaLabel, initital_state)
+      return builder.getAutomaton
+    }
+
+    val sink_state = builder.getNewState
+    builder.setAccept(sink_state, isAccepting = true)
+
+    val first_letter = str.head
+
+    builder.addTransition(initital_state, builder.LabelOps.interval((first_letter+1).toChar, Char.MaxValue), sink_state)
+    builder.addTransition(sink_state, builder.LabelOps.sigmaLabel, sink_state)
+
+    val states =
+      (for (n <- 0 to str.length) yield builder.getNewState).toIndexedSeq
+
+    builder.addTransition(initital_state, builder.LabelOps.singleton(first_letter), states(0))
+    val remaining_str = str.tail
+
+    for ((c,n) <- remaining_str.iterator.zipWithIndex) {
+      // we read c = x -> keep parsing
+      builder.addTransition(states(n),builder.LabelOps.singleton(c), states(n+1))
+      // we read c < x -> go to sink state
+      builder.addTransition(states(n),builder.LabelOps.interval((c+1).toChar, Char.MaxValue), sink_state)
+      builder.setAccept(states(n), isAccepting = true)
+    }
+    // we are equal up to this point -> can read any letter afterwards and be bigger
+    builder.addTransition(states.last, builder.LabelOps.sigmaLabel, states.last)
+
+    builder.getAutomaton
+  }
+
+  /**
    * Check whether we should avoid ever minimising the given automaton.
    */
   def neverMinimize(aut : BAutomaton) : Boolean =

--- a/src/main/scala/ostrich/automata/BricsAutomaton.scala
+++ b/src/main/scala/ostrich/automata/BricsAutomaton.scala
@@ -185,7 +185,7 @@ object BricsAutomaton {
     builder.addTransition(sink_state, builder.LabelOps.sigmaLabel, sink_state)
 
     val states =
-      (for (n <- 0 to str.length) yield builder.getNewState).toIndexedSeq
+      (for (n <- 0 until str.length) yield builder.getNewState).toIndexedSeq
 
     // add transition to rest of the automaton
     builder.addTransition(initital_state, builder.LabelOps.singleton(first_letter), states(0))
@@ -233,9 +233,9 @@ object BricsAutomaton {
     builder.addTransition(sink_state, builder.LabelOps.sigmaLabel, sink_state)
 
     val states =
-      (for (n <- 0 to str.length) yield builder.getNewState).toIndexedSeq
+      (for (n <- 0 until str.length) yield builder.getNewState).toIndexedSeq
 
-    builder.addTransition(initital_state, builder.LabelOps.singleton(first_letter), states(0))
+    builder.addTransition(initital_state, builder.LabelOps.singleton(first_letter), states.head)
     val remaining_str = str.tail
 
     for ((c,n) <- remaining_str.iterator.zipWithIndex) {
@@ -246,6 +246,7 @@ object BricsAutomaton {
       builder.setAccept(states(n), isAccepting = true)
     }
     // we are equal up to this point -> can read any letter afterwards and be bigger
+    builder.setAccept(states.last, isAccepting = true)
     builder.addTransition(states.last, builder.LabelOps.sigmaLabel, states.last)
 
     builder.getAutomaton

--- a/src/test/scala/SMTLIBTests.scala
+++ b/src/test/scala/SMTLIBTests.scala
@@ -462,5 +462,5 @@ object SMTLIBTests extends Properties("SMTLIBTests") {
   property("str-len11") =
     checkFile("tests/str-len11.smt2", "sat")
   property("str-len12") =
-    checkFile("tests/str-len12.smt2", "unsat")
+    checkFile("tests/str-len12.smt2", "sat")
 }

--- a/src/test/scala/SMTLIBTests.scala
+++ b/src/test/scala/SMTLIBTests.scala
@@ -439,4 +439,28 @@ object SMTLIBTests extends Properties("SMTLIBTests") {
     checkFile("tests/bug-56-replace-bug2.smt2", "sat")
   property("bug-58-replace-re") =
     checkFile("tests/bug-58-replace-re.smt2", "sat")
+  property("str-len") =
+    checkFile("tests/str-len.smt2", "unsat")
+  property("str-len2") =
+    checkFile("tests/str-len2.smt2", "sat")
+  property("str-len3") =
+    checkFile("tests/str-len3.smt2", "sat")
+  property("str-len4") =
+    checkFile("tests/str-len4.smt2", "unsat")
+  property("str-len5") =
+    checkFile("tests/str-len5.smt2", "sat")
+  property("str-len6") =
+    checkFile("tests/str-len6.smt2", "sat")
+  property("str-len7") =
+    checkFile("tests/str-len7.smt2", "sat")
+  property("str-len8") =
+    checkFile("tests/str-len8.smt2", "unsat")
+  property("str-len9") =
+    checkFile("tests/str-len9.smt2", "sat")
+  property("str-len10") =
+    checkFile("tests/str-len10.smt2", "unsat")
+  property("str-len11") =
+    checkFile("tests/str-len11.smt2", "sat")
+  property("str-len12") =
+    checkFile("tests/str-len12.smt2", "unsat")
 }

--- a/tests/str-len.smt2
+++ b/tests/str-len.smt2
@@ -1,0 +1,7 @@
+(set-logic QF_)
+
+(declare-fun x () String)
+
+(assert (= 1 (str.len x)))
+(assert (str.<= x ""))
+(check-sat)

--- a/tests/str-len10.smt2
+++ b/tests/str-len10.smt2
@@ -1,0 +1,6 @@
+(set-logic QF_)
+
+(declare-fun x () String)
+(assert (= "abc" x))
+(assert (str.<= "b" x))
+(check-sat)

--- a/tests/str-len11.smt2
+++ b/tests/str-len11.smt2
@@ -1,0 +1,7 @@
+(set-logic QF_)
+
+(declare-fun x () String)
+(assert (= 1 (str.len x)))
+(assert (str.<= "a" x))
+(assert (str.<= x "c"))
+(check-sat)

--- a/tests/str-len12.smt2
+++ b/tests/str-len12.smt2
@@ -1,0 +1,7 @@
+(set-logic QF_)
+
+(declare-fun x () String)
+(assert (= 1 (str.len x)))
+(assert (str.<= "a" x))
+(assert (str.<= x "b"))
+(check-sat)

--- a/tests/str-len2.smt2
+++ b/tests/str-len2.smt2
@@ -1,0 +1,6 @@
+(set-logic QF_)
+
+(declare-fun x () String)
+
+(assert (str.<= x ""))
+(check-sat)

--- a/tests/str-len3.smt2
+++ b/tests/str-len3.smt2
@@ -1,0 +1,7 @@
+(set-logic QF_)
+
+(declare-fun x () String)
+
+(assert (= 1 (str.len x)))
+(assert (str.<= x "cba"))
+(check-sat)

--- a/tests/str-len4.smt2
+++ b/tests/str-len4.smt2
@@ -1,0 +1,7 @@
+(set-logic QF_)
+
+(declare-fun x () String)
+
+(assert (= x "cbaa"))
+(assert (str.<= x "cba"))
+(check-sat)

--- a/tests/str-len5.smt2
+++ b/tests/str-len5.smt2
@@ -1,0 +1,7 @@
+(set-logic QF_)
+
+(declare-fun x () String)
+
+(assert (= 4 (str.len x)))
+(assert (str.<= x "cba"))
+(check-sat)

--- a/tests/str-len6.smt2
+++ b/tests/str-len6.smt2
@@ -1,0 +1,7 @@
+(set-logic QF_)
+
+(declare-fun x () String)
+
+(assert (= x "cab"))
+(assert (str.<= x "cba"))
+(check-sat)

--- a/tests/str-len7.smt2
+++ b/tests/str-len7.smt2
@@ -1,0 +1,6 @@
+(set-logic QF_)
+
+(declare-fun x () String)
+(assert (= 1 (str.len x)))
+(assert (str.<= "cba" x))
+(check-sat)

--- a/tests/str-len8.smt2
+++ b/tests/str-len8.smt2
@@ -1,0 +1,6 @@
+(set-logic QF_)
+
+(declare-fun x () String)
+
+(assert (str.<= "cba" "cab"))
+(check-sat)

--- a/tests/str-len9.smt2
+++ b/tests/str-len9.smt2
@@ -1,0 +1,6 @@
+(set-logic QF_)
+
+(declare-fun x () String)
+(assert (= 1 (str.len x)))
+(assert (str.<= "" x))
+(check-sat)


### PR DESCRIPTION
I have added partial support to the SMTLIB function (str.<= String String Bool :chainable). If one of the sides is a constant then the expression is transformed into an automaton.
This is a partial fix for Issue [(https://github.com/uuverifiers/princess/issues/9#issue-2001063828)]
