### PR TITLE
Automata length

### DIFF
--- a/src/main/scala/ostrich/OstrichSolver.scala
+++ b/src/main/scala/ostrich/OstrichSolver.scala
@@ -109,12 +109,12 @@ class OstrichSolver(theory : OstrichStringTheory,
     var is_monadic = true
     breakable {
       for (atom <- pos_length) {
-        if (atom(1).head._1.intValueSafe != 1){
-          // TODO handle case if the variable inside str_len is not 1
-          is_monadic = false
-          break
-        }
         if (!atom(1).isConstant) {
+          if (atom(1).head._1.intValueSafe != 1){
+            // TODO handle case if the variable inside str_len is not 1
+            is_monadic = false
+            break
+          }
           length_vars.add(atom)
           if (atom(1).length > 1){
             is_monadic = false
@@ -171,8 +171,7 @@ class OstrichSolver(theory : OstrichStringTheory,
       }
     }
 
-
-    val containsLength = !(atoms positiveLitsWithPred p(str_len)).isEmpty && !is_monadic
+    val containsLength = (atoms positiveLitsWithPred p(str_len)).nonEmpty && !is_monadic
     val eagerMode = flags.eagerAutomataOperations
 
 

--- a/src/main/scala/ostrich/OstrichSolver.scala
+++ b/src/main/scala/ostrich/OstrichSolver.scala
@@ -210,6 +210,7 @@ class OstrichSolver(theory : OstrichStringTheory,
 
     ////////////////////////////////////////////////////////////////////////////
 
+    // If no len constraints needed, add the computed length regexes and add them
     if (is_monadic){
       regexes ++= createBoundedLengthRegex(regex_ineq_vars, lower_bounds,upper_bounds)
       regexes ++= createEqRegex(regex_length_vars)

--- a/src/main/scala/ostrich/automata/BricsAutomaton.scala
+++ b/src/main/scala/ostrich/automata/BricsAutomaton.scala
@@ -153,6 +153,46 @@ object BricsAutomaton {
   def makeAnyString() : BricsAutomaton =
       new BricsAutomaton(BAutomaton.makeAnyString)
 
+  def eqLengthAutomata(length : Int) : BricsAutomaton = {
+    val builder = new BricsAutomatonBuilder
+
+    val states =
+      (for (n <- 0 to length) yield builder.getNewState).toIndexedSeq
+
+
+    builder.setInitialState(states(0))
+    for (i <- 0 until length){
+      builder.addTransition(states(i), BricsTLabelOps.sigmaLabel,states(i+1))
+    }
+    builder.setAccept(states(length), isAccepting = true)
+    builder.getAutomaton
+  }
+
+  def boundedLengthAutomata(lowerBound : Int, upperBound : Option[Int]) : BricsAutomaton = {
+    val upperBoundValue = upperBound.getOrElse(-1)
+    val numberOfStates = math.max(lowerBound,upperBoundValue)
+
+    val builder = new BricsAutomatonBuilder
+    // lb k -> have k+1 states and last state with sigma and accept
+    // ub k -> return k+1 states, every state up to k accept, no loop on last
+    val states =
+      (for (_ <- 0 to numberOfStates) yield builder.getNewState).toIndexedSeq
+
+    builder.setInitialState(states(0))
+    for (i <- 0 until numberOfStates){
+      builder.addTransition(states(i), BricsTLabelOps.sigmaLabel,states(i+1))
+      if (i >= lowerBound && i <= upperBoundValue){
+        builder.setAccept(states(i), isAccepting = true)
+      }
+    }
+    builder.setAccept(states(numberOfStates), isAccepting = true)
+    // no upper bound -> last state has loop
+    if (upperBoundValue == -1){
+      builder.addTransition(states(numberOfStates), BricsTLabelOps.sigmaLabel,states(numberOfStates))
+    }
+    builder.getAutomaton
+  }
+
   /**
    * A new automaton that accepts all strings x <= str (lexicographical ordering)
    */


### PR DESCRIPTION
Disable length flags in Exploration if all str_len predicates are monadic. 
Detection of monadic length constraints is done conservatively, if they are obviously monadic the check passes, otherwise length flag stays activated.