### PR TITLE
ostrich: fix bugs of replacee concrete word

### DIFF
--- a/src/main/scala/ostrich/preop/ReplacePreOp.scala
+++ b/src/main/scala/ostrich/preop/ReplacePreOp.scala
@@ -167,7 +167,7 @@ object ReplacePreOpWord {
           // next char either part of next match or last char and not
           // buffered
           val rejectedOutput = OutputOp(rejectedOldMatchPart, NOP, "")
-          val rejectedOutputFin = OutputOp(rejectedOldMatchPart, Plus(0), "")
+          val rejectedOutputFin = OutputOp(buffer, Plus(0), "")
 
           builder.addTransition(states(i),
                                 (charNext, charNext),


### PR DESCRIPTION
It seems that the word after failed matching is not recover properly