### PR TITLE
Build witness in reverse in AutomataUtils for efficiency

### DIFF
--- a/src/main/scala/ostrich/automata/AutomataUtils.scala
+++ b/src/main/scala/ostrich/automata/AutomataUtils.scala
@@ -283,9 +283,10 @@ object AutomataUtils {
         val byChar = headAut.LabelOps.enumLetters(lbl).next
         val reached = (reachedPos, reachedNeg)
         if (visitedStates.add(reached)) {
-          val nextWitness = witness :+ byChar
-          if (isAccepting(autsList, negAutsList, reached))
-            return Some(nextWitness)
+          val nextWitness = byChar +: witness
+          if (isAccepting(autsList, negAutsList, reached)) {
+            return Some(nextWitness.reverse)
+          }
           todo push (reached, nextWitness)
         }
       }


### PR DESCRIPTION
Because the witness is kept for each head of the search, the memory usage is n squared if the witness is kept in the normal order. By storing in reverse, Scala's linked lists mean the prefix of the witness can be shared between different heads.